### PR TITLE
Add Theme Toggle / Dark Mode

### DIFF
--- a/README.md
+++ b/README.md
@@ -175,7 +175,6 @@ The theme_toggle component accepts the following attributes:
     - nil or omitted: Uses the provided JavaScript (must be set up as described above).
     - String: Name of a custom event or JavaScript function to be called.
     - 1-arity function: Called with the selected theme as an argument.
-    - 0-arity function: Called without arguments; theme details are added to the returned JS commands.
 
 ### Examples
 

--- a/README.md
+++ b/README.md
@@ -20,7 +20,7 @@ This library is my attemp to port [shadcn ui](https://ui.shadcn.com/) to Phoenix
 ```elixir
 def deps do
   [
-    {:salad_ui, "~> 0.4.2"}
+    {:salad_ui, "~> 0.5.2"}
   ]
 end
 ```
@@ -107,6 +107,97 @@ SaladUI use `tails` to properly merge Tailwindcss classes
 config :tails, colors_file: Path.join(File.cwd!(), "assets/tailwind.colors.json")
 ```
 
+## Theme Toggle
+
+The Theme Toggle component provides an easy way to implement theme switching in your Phoenix LiveView application.
+
+### Useage 
+1. Add *darkMode: ["class"]* to your module.exports in tailwind.config.js:
+```
+module.exports = {
+  darkMode: ["class"],
+  etc...
+}
+```
+
+2. Add the Theme Toggle component to your layout:
+
+  ```elixir
+  <SaladUI.ThemeToggle.theme_toggle />
+  ```
+
+  Typically, you'd place this in your root layout (lib/your_app_web/components/layouts/root.html.heex) or app layout (lib/your_app_web/components/layouts/app.html.heex).
+
+3. Implement theme switching functionality: You can either use the provided JavaScript or implement your own theme switching logic.
+
+Using the Provided JavaScript
+Add the following code to your app.js (usually located at assets/js/app.js):
+
+```
+//! Theme Toggle
+document.addEventListener('DOMContentLoaded', (event) => {
+  const setTheme = (theme) => {
+    if (theme === 'system') {
+      const systemTheme = window.matchMedia('(prefers-color-scheme: dark)').matches ? 'dark' : 'light';
+      document.documentElement.classList.remove('light', 'dark');
+      document.documentElement.classList.add(systemTheme);
+    } else {
+      document.documentElement.classList.remove('light', 'dark');
+      document.documentElement.classList.add(theme);
+    }
+    localStorage.setItem('theme', theme);
+  };
+
+  const savedTheme = localStorage.getItem('theme') || 'system';
+  setTheme(savedTheme);
+
+  window.addEventListener("set_theme", (e) => {
+    setTheme(e.detail.theme);
+  });
+
+  window.matchMedia('(prefers-color-scheme: dark)').addEventListener('change', e => {
+    if (localStorage.getItem('theme') === 'system') {
+      setTheme('system');
+    }
+  });
+});
+```
+
+Using Custom Theme Switching Logic
+If you prefer to use your own theme switching logic, you must provide the on_theme_change attribute to the component.
+
+### Customization
+The theme_toggle component accepts the following attributes:
+
+- id (string, optional): Custom ID for the toggle container. Default: "theme-toggle"
+- class (string, optional): Additional CSS classes for the toggle container.
+- on_theme_change (any, optional): Custom handler for theme changes. Accepts:
+    - nil or omitted: Uses the provided JavaScript (must be set up as described above).
+    - String: Name of a custom event or JavaScript function to be called.
+    - 1-arity function: Called with the selected theme as an argument.
+    - 0-arity function: Called without arguments; theme details are added to the returned JS commands.
+
+### Examples
+
+1. Using default behaviour:
+```
+<SaladUI.ThemeToggle.theme_toggle />
+```
+
+2. Using a custom event name:
+```
+<SaladUI.ThemeToggle.theme_toggle on_theme_change="myCustomThemeEvent" />
+```
+
+3. Using a custom function:
+```
+<SaladUI.ThemeToggle.theme_toggle on_theme_change={fn theme -> JS.push("save_theme", value: %{theme: theme}) end} />
+```
+
+4. Customizing ID and class:
+```
+<SaladUI.ThemeToggle.theme_toggle id="my-theme-toggle" class="absolute top-4 right-4" />
+```
 
 ## Development
 
@@ -169,4 +260,5 @@ To run the failing tests only, just run `mix test.watch --stale`.
 - ✅ Table
 - ✅ Tabs
 - ✅ Textarea
+- ✅ Theme Toggle
 - ✅ Tooltip

--- a/lib/salad_ui.ex
+++ b/lib/salad_ui.ex
@@ -48,6 +48,7 @@ defmodule SaladUI do
       import SaladUI.Table
       import SaladUI.Tabs
       import SaladUI.Textarea
+      import SaladUI.ThemeToggle
       import SaladUI.Tooltip
     end
   end

--- a/lib/salad_ui/menu.ex
+++ b/lib/salad_ui/menu.ex
@@ -42,7 +42,7 @@ defmodule SaladUI.Menu do
     ~H"""
     <div
       class={[
-        "min-w-[8rem] overflow-hidden rounded-md border bg-popover p-1 text-popover-foreground shadow-md",
+        "min-w-[8rem] overflow-hidden rounded-md border border-border bg-popover p-1 text-popover-foreground shadow-md",
         @class
       ]}
       {@rest}

--- a/lib/salad_ui/theme_toggle.ex
+++ b/lib/salad_ui/theme_toggle.ex
@@ -1,0 +1,186 @@
+defmodule SaladUI.ThemeToggle do
+  @moduledoc """
+  Implementation of Theme Toggle from https://ui.shadcn.com/docs/dark-mode/next
+
+  ## Theme Toggle
+  The Theme Toggle component provides an easy way to implement theme switching in your Phoenix LiveView application.
+
+  ### Useage
+  1. Add *darkMode: ["class"]* to your module.exports in tailwind.config.js:
+  ```
+  module.exports = {
+    darkMode: ["class"],
+    etc...
+  }
+  ```
+
+  2. Add the Theme Toggle component to your layout:
+
+    ```elixir
+    <SaladUI.ThemeToggle.theme_toggle />
+    ```
+
+    Typically, you'd place this in your root layout (lib/your_app_web/components/layouts/root.html.heex) or app layout (lib/your_app_web/components/layouts/app.html.heex).
+
+  3. Implement theme switching functionality: You can either use the provided JavaScript or implement your own theme switching logic.
+
+  Using the Provided JavaScript
+  Add the following code to your app.js (usually located at assets/js/app.js):
+
+  ```
+  //! Theme Toggle
+  document.addEventListener('DOMContentLoaded', (event) => {
+    const setTheme = (theme) => {
+      if (theme === 'system') {
+        const systemTheme = window.matchMedia('(prefers-color-scheme: dark)').matches ? 'dark' : 'light';
+        document.documentElement.classList.remove('light', 'dark');
+        document.documentElement.classList.add(systemTheme);
+      } else {
+        document.documentElement.classList.remove('light', 'dark');
+        document.documentElement.classList.add(theme);
+      }
+      localStorage.setItem('theme', theme);
+    };
+
+    const savedTheme = localStorage.getItem('theme') || 'system';
+    setTheme(savedTheme);
+
+    window.addEventListener("set_theme", (e) => {
+      setTheme(e.detail.theme);
+    });
+
+    window.matchMedia('(prefers-color-scheme: dark)').addEventListener('change', e => {
+      if (localStorage.getItem('theme') === 'system') {
+        setTheme('system');
+      }
+    });
+  });
+  ```
+
+  Using Custom Theme Switching Logic
+  If you prefer to use your own theme switching logic, you must provide the on_theme_change attribute to the component.
+
+  ### Customization
+  The theme_toggle component accepts the following attributes:
+
+  - id (string, optional): Custom ID for the toggle container. Default: "theme-toggle"
+  - class (string, optional): Additional CSS classes for the toggle container.
+  - on_theme_change (any, optional): Custom handler for theme changes. Accepts:
+      - nil or omitted: Uses the provided JavaScript (must be set up as described above).
+      - String: Name of a custom event or JavaScript function to be called.
+      - 1-arity function: Called with the selected theme as an argument.
+
+  ### Examples
+
+  1. Using default behaviour:
+  ```
+  <SaladUI.ThemeToggle.theme_toggle />
+  ```
+
+  2. Using a custom event name:
+  ```
+  <SaladUI.ThemeToggle.theme_toggle on_theme_change="myCustomThemeEvent" />
+  ```
+
+  3. Using a custom function:
+  ```
+  <SaladUI.ThemeToggle.theme_toggle on_theme_change={fn theme -> JS.push("save_theme", value: %{theme: theme}) end} />
+  ```
+
+  4. Customizing ID and class:
+  ```
+  <SaladUI.ThemeToggle.theme_toggle id="my-theme-toggle" class="absolute top-4 right-4" />
+  ```
+  """
+  use     SaladUI, :component
+
+  alias   Phoenix.LiveView.JS
+  import  SaladUI.{DropdownMenu, Button, Menu}
+
+  attr :id, :string, default: "theme-toggle"
+  attr :class, :string, default: ""
+  attr :on_theme_change, :any, default: "set_theme", doc: "A string (event name) or 1-arity function to handle theme changes.  Omit to use default js functions"
+
+  def theme_toggle(assigns) do
+    ~H"""
+    <div class={@class}>
+      <.dropdown_menu id={@id}>
+        <.dropdown_menu_trigger>
+          <.button variant="outline" size="icon" class="relative">
+            <.sun_icon class="h-[1.2rem] w-[1.2rem] rotate-0 scale-100 transition-all dark:-rotate-90 dark:scale-0">
+            </.sun_icon>
+            <.moon_icon class="absolute h-[1.2rem] w-[1.2rem] rotate-90 scale-0 transition-all text-black dark:text-white dark:rotate-0 dark:scale-100">
+            </.moon_icon>
+            <span class="sr-only">
+            Toggle theme
+            </span>
+          </.button>
+        </.dropdown_menu_trigger>
+
+        <.dropdown_menu_content align="end">
+          <.menu class="w-32">
+            <.menu_item id="light-theme" phx-click={theme_change_event("light", @on_theme_change)}>
+              Light
+            </.menu_item>
+            <.menu_item id="dark-theme" phx-click={theme_change_event("dark", @on_theme_change)}>
+              Dark
+            </.menu_item>
+            <.menu_item id="system-theme" phx-click={theme_change_event("system", @on_theme_change)}>
+              System
+            </.menu_item>
+          </.menu>
+        </.dropdown_menu_content>
+      </.dropdown_menu>
+    </div>
+    """
+  end
+
+  defp theme_change_event(theme, on_theme_change) when is_binary(on_theme_change) do
+    JS.dispatch(on_theme_change, detail: %{theme: theme})
+  end
+
+  defp theme_change_event(theme, on_theme_change) when is_function(on_theme_change, 1) do
+    on_theme_change.(theme)
+  end
+
+  defp sun_icon(assigns) do
+    ~H"""
+    <svg
+      xmlns="http://www.w3.org/2000/svg"
+      width="24"
+      height="24"
+      viewBox="0 0 24 24"
+      fill="none"
+      stroke="currentColor"
+      stroke-width="2"
+      stroke-linecap="round"
+      stroke-linejoin="round"
+      class={@class}
+    >
+      <circle cx="12" cy="12" r="5" />
+      <line x1="12" y1="1" x2="12" y2="3" />
+      <line x1="12" y1="21" x2="12" y2="23" />
+      <line x1="4.22" y1="4.22" x2="5.64" y2="5.64" />
+      <line x1="18.36" y1="18.36" x2="19.78" y2="19.78" />
+      <line x1="1" y1="12" x2="3" y2="12" />
+      <line x1="21" y1="12" x2="23" y2="12" />
+      <line x1="4.22" y1="19.78" x2="5.64" y2="18.36" />
+      <line x1="18.36" y1="5.64" x2="19.78" y2="4.22" />
+    </svg>
+    """
+  end
+
+  #  This is a the same icon used by shadcn ui, using the svg from https://rocketicons.io/en/icons/rx/rx-moon
+  defp moon_icon(assigns) do
+    ~H"""
+     <svg viewBox="0 0 15 15" fill="none" xmlns="http://www.w3.org/2000/svg" class={@class}>
+      <path
+        fill-rule="evenodd"
+        clip-rule="evenodd"
+        d="M2.89998 0.499976C2.89998 0.279062 2.72089 0.0999756 2.49998 0.0999756C2.27906 0.0999756 2.09998 0.279062 2.09998 0.499976V1.09998H1.49998C1.27906 1.09998 1.09998 1.27906 1.09998 1.49998C1.09998 1.72089 1.27906 1.89998 1.49998 1.89998H2.09998V2.49998C2.09998 2.72089 2.27906 2.89998 2.49998 2.89998C2.72089 2.89998 2.89998 2.72089 2.89998 2.49998V1.89998H3.49998C3.72089 1.89998 3.89998 1.72089 3.89998 1.49998C3.89998 1.27906 3.72089 1.09998 3.49998 1.09998H2.89998V0.499976ZM5.89998 3.49998C5.89998 3.27906 5.72089 3.09998 5.49998 3.09998C5.27906 3.09998 5.09998 3.27906 5.09998 3.49998V4.09998H4.49998C4.27906 4.09998 4.09998 4.27906 4.09998 4.49998C4.09998 4.72089 4.27906 4.89998 4.49998 4.89998H5.09998V5.49998C5.09998 5.72089 5.27906 5.89998 5.49998 5.89998C5.72089 5.89998 5.89998 5.72089 5.89998 5.49998V4.89998H6.49998C6.72089 4.89998 6.89998 4.72089 6.89998 4.49998C6.89998 4.27906 6.72089 4.09998 6.49998 4.09998H5.89998V3.49998ZM1.89998 6.49998C1.89998 6.27906 1.72089 6.09998 1.49998 6.09998C1.27906 6.09998 1.09998 6.27906 1.09998 6.49998V7.09998H0.499976C0.279062 7.09998 0.0999756 7.27906 0.0999756 7.49998C0.0999756 7.72089 0.279062 7.89998 0.499976 7.89998H1.09998V8.49998C1.09998 8.72089 1.27906 8.89997 1.49998 8.89997C1.72089 8.89997 1.89998 8.72089 1.89998 8.49998V7.89998H2.49998C2.72089 7.89998 2.89998 7.72089 2.89998 7.49998C2.89998 7.27906 2.72089 7.09998 2.49998 7.09998H1.89998V6.49998ZM8.54406 0.98184L8.24618 0.941586C8.03275 0.917676 7.90692 1.1655 8.02936 1.34194C8.17013 1.54479 8.29981 1.75592 8.41754 1.97445C8.91878 2.90485 9.20322 3.96932 9.20322 5.10022C9.20322 8.37201 6.82247 11.0878 3.69887 11.6097C3.45736 11.65 3.20988 11.6772 2.96008 11.6906C2.74563 11.702 2.62729 11.9535 2.77721 12.1072C2.84551 12.1773 2.91535 12.2458 2.98667 12.3128L3.05883 12.3795L3.31883 12.6045L3.50684 12.7532L3.62796 12.8433L3.81491 12.9742L3.99079 13.089C4.11175 13.1651 4.23536 13.2375 4.36157 13.3059L4.62496 13.4412L4.88553 13.5607L5.18837 13.6828L5.43169 13.7686C5.56564 13.8128 5.70149 13.8529 5.83857 13.8885C5.94262 13.9155 6.04767 13.9401 6.15405 13.9622C6.27993 13.9883 6.40713 14.0109 6.53544 14.0298L6.85241 14.0685L7.11934 14.0892C7.24637 14.0965 7.37436 14.1002 7.50322 14.1002C11.1483 14.1002 14.1032 11.1453 14.1032 7.50023C14.1032 7.25044 14.0893 7.00389 14.0623 6.76131L14.0255 6.48407C13.991 6.26083 13.9453 6.04129 13.8891 5.82642C13.8213 5.56709 13.7382 5.31398 13.6409 5.06881L13.5279 4.80132L13.4507 4.63542L13.3766 4.48666C13.2178 4.17773 13.0353 3.88295 12.8312 3.60423L12.6782 3.40352L12.4793 3.16432L12.3157 2.98361L12.1961 2.85951L12.0355 2.70246L11.8134 2.50184L11.4925 2.24191L11.2483 2.06498L10.9562 1.87446L10.6346 1.68894L10.3073 1.52378L10.1938 1.47176L9.95488 1.3706L9.67791 1.2669L9.42566 1.1846L9.10075 1.09489L8.83599 1.03486L8.54406 0.98184ZM10.4032 5.30023C10.4032 4.27588 10.2002 3.29829 9.83244 2.40604C11.7623 3.28995 13.1032 5.23862 13.1032 7.50023C13.1032 10.593 10.596 13.1002 7.50322 13.1002C6.63646 13.1002 5.81597 12.9036 5.08355 12.5522C6.5419 12.0941 7.81081 11.2082 8.74322 10.0416C8.87963 10.2284 9.10028 10.3497 9.34928 10.3497C9.76349 10.3497 10.0993 10.0139 10.0993 9.59971C10.0993 9.24256 9.84965 8.94373 9.51535 8.86816C9.57741 8.75165 9.63653 8.63334 9.6926 8.51332C9.88358 8.63163 10.1088 8.69993 10.35 8.69993C11.0403 8.69993 11.6 8.14028 11.6 7.44993C11.6 6.75976 11.0406 6.20024 10.3505 6.19993C10.3853 5.90487 10.4032 5.60464 10.4032 5.30023Z"
+        fill="currentColor"
+      />
+    </svg>
+    """
+  end
+end

--- a/test/salad_ui/menu_test.exs
+++ b/test/salad_ui/menu_test.exs
@@ -128,7 +128,7 @@ defmodule SaladUi.MenuTest do
         |> clean_string()
 
       assert html =~
-               "<div class=\"min-w-[8rem] overflow-hidden rounded-md border bg-popover p-1 text-popover-foreground shadow-md top-0 left-full\">"
+               "<div class=\"min-w-[8rem] overflow-hidden rounded-md border border-border bg-popover p-1 text-popover-foreground shadow-md top-0 left-full\">"
 
       assert html =~ "<div class=\"\" role=\"group\""
       assert html =~ "Profile"


### PR DESCRIPTION
Add shadcn's Theme Toggle and support for darkmode.

Also, menu has been updated with the border-border class, which is needed to use the correctly colored border in dark mode

<!-- Generated by sourcery-ai[bot]: start summary -->

## Summary by Sourcery

This pull request adds a Theme Toggle component to enable dark mode support in Phoenix LiveView applications. It also updates the menu component for proper border coloring in dark mode and includes comprehensive documentation and tests for the new feature.

- **New Features**:
    - Introduced a Theme Toggle component to support dark mode in Phoenix LiveView applications.
- **Enhancements**:
    - Updated the menu component to include the 'border-border' class for proper border coloring in dark mode.
- **Documentation**:
    - Added documentation for the new Theme Toggle component, including usage instructions, customization options, and examples.
- **Tests**:
    - Updated tests for the menu component to reflect the addition of the 'border-border' class.

<!-- Generated by sourcery-ai[bot]: end summary -->