### PR TITLE
Refactor input components

### DIFF
--- a/lib/salad_ui/checkbox.ex
+++ b/lib/salad_ui/checkbox.ex
@@ -8,20 +8,19 @@ defmodule SaladUI.Checkbox do
   ## Examples:
       <.checkbox class="!border-destructive" name="agree" value={true} />
   """
-  attr :id, :any, default: nil
   attr :name, :any, default: nil
   attr :value, :any, default: nil
+  attr :"default-value", :any, values: [true, false, "true", "false"], default: false
   attr :field, Phoenix.HTML.FormField
   attr :class, :string, default: nil
   attr :rest, :global
 
   def checkbox(assigns) do
     assigns =
-      assigns
-      |> prepare_assign()
-      |> assign_new(:checked, fn ->
-        Phoenix.HTML.Form.normalize_value("checkbox", assigns.value)
-      end)
+      prepare_assign(assigns)
+
+    assigns =
+      assign_new(assigns, :checked, fn -> Phoenix.HTML.Form.normalize_value("checkbox", assigns.value) end)
 
     ~H"""
     <input type="hidden" name={@name} value="false" />
@@ -33,7 +32,6 @@ defmodule SaladUI.Checkbox do
           @class
         ])
       }
-      id={@id || @name}
       name={@name}
       value="true"
       checked={@checked}

--- a/lib/salad_ui/helpers.ex
+++ b/lib/salad_ui/helpers.ex
@@ -7,14 +7,23 @@ defmodule SaladUI.Helpers do
   """
   def prepare_assign(%{field: %Phoenix.HTML.FormField{} = field} = assigns) do
     assigns
-    |> assign(field: nil, id: assigns.id || field.id)
+    |> assign(field: nil, id: assigns[:id] || field.id)
     # |> assign(:errors, Enum.map(field.errors, &translate_error(&1)))
-    |> assign_new(:name, fn -> if assigns[:multiple], do: field.name <> "[]", else: field.name end)
-    |> assign_new(:value, fn -> field.value end)
+    |> assign(:name, if(assigns[:multiple], do: field.name <> "[]", else: field.name))
+    |> assign(:value, field.value)
+    |> prepare_assign()
   end
 
+  # use default value if value is not provided or empty
   def prepare_assign(assigns) do
-    assigns
+    value =
+      if assigns[:value] in [nil, "", []] do
+        assigns[:"default-value"]
+      else
+        assigns[:value]
+      end
+
+    assign(assigns, value: value)
   end
 
   # normalize_integer
@@ -22,7 +31,7 @@ defmodule SaladUI.Helpers do
 
   def normalize_integer(value) when is_binary(value) do
     case Integer.parse(value) do
-      {:ok, integer} -> integer
+      {integer, _} -> integer
       _ -> nil
     end
   end

--- a/lib/salad_ui/input.ex
+++ b/lib/salad_ui/input.ex
@@ -19,6 +19,8 @@ defmodule SaladUI.Input do
     default: "text",
     values: ~w(date datetime-local email file hidden month number password tel text time url week)
 
+  attr :"default-value", :any
+
   attr :field, Phoenix.HTML.FormField, doc: "a form field struct retrieved from the form, for example: @form[:email]"
 
   attr :class, :string, default: nil
@@ -26,7 +28,10 @@ defmodule SaladUI.Input do
 
   def input(assigns) do
     assigns = prepare_assign(assigns)
-    rest = Map.merge(assigns.rest, Map.take(assigns, [:id, :name, :value, :type]))
+
+    rest =
+      Map.merge(assigns.rest, Map.take(assigns, [:id, :name, :value, :type]))
+
     assigns = assign(assigns, :rest, rest)
 
     ~H"""

--- a/lib/salad_ui/radio_group.ex
+++ b/lib/salad_ui/radio_group.ex
@@ -25,10 +25,13 @@ defmodule SaladUI.RadioGroup do
   """
   attr :name, :string, default: nil
   attr :value, :any, default: nil
+  attr :"default-value", :any
+  attr :field, Phoenix.HTML.FormField, doc: "a form field struct retrieved from the form, for example: @form[:email]"
   attr :class, :string, default: nil
   slot :inner_block, required: true
 
   def radio_group(assigns) do
+    assigns = prepare_assign(assigns)
     assigns = assign(assigns, :builder, %{name: assigns.name, value: assigns.value})
 
     ~H"""
@@ -63,6 +66,7 @@ defmodule SaladUI.RadioGroup do
         type="radio"
         class="hidden peer/radio"
         name={@builder.name}
+        value={@value}
         checked={normalize_boolean(@checked) || @builder.value == @value}
         {@rest}
       />

--- a/lib/salad_ui/select.ex
+++ b/lib/salad_ui/select.ex
@@ -34,6 +34,9 @@ defmodule SaladUI.Select do
   attr :id, :string, default: nil
   attr :name, :any, default: nil
   attr :value, :any, default: nil, doc: "The value of the select"
+  attr :"default-value", :any, default: nil, doc: "The default value of the select"
+
+  attr :field, Phoenix.HTML.FormField, doc: "a form field struct retrieved from the form, for example: @form[:email]"
 
   attr :label, :string,
     default: nil,
@@ -46,8 +49,10 @@ defmodule SaladUI.Select do
   attr :rest, :global
 
   def select(assigns) do
+    assigns = prepare_assign(assigns)
+
     assigns =
-      assign(assigns, :instance, %{
+      assign(assigns, :builder, %{
         id: assigns.id,
         name: assigns.name,
         value: assigns.value,
@@ -66,13 +71,12 @@ defmodule SaladUI.Select do
       x-toggle-select={toggle_select(@id)}
       phx-click-away={JS.exec("x-hide-select")}
     >
-      <%= render_slot(@inner_block, @instance) %>
+      <%= render_slot(@inner_block, @builder) %>
     </div>
     """
   end
 
-  attr :target, :string, required: true
-  attr :instance, :map, required: true, doc: "The instance of the select component"
+  attr :builder, :map, required: true, doc: "The builder of the select component"
   attr :class, :string, default: nil
   attr :rest, :global
 
@@ -86,12 +90,12 @@ defmodule SaladUI.Select do
           @class
         ])
       }
-      phx-click={toggle_select(@instance.id)}
+      phx-click={toggle_select(@builder.id)}
       {@rest}
     >
       <span
         class="select-value pointer-events-none before:content-[attr(data-content)]"
-        data-content={@instance.label || @instance.value || @instance.placeholder}
+        data-content={@builder.label || @builder.value || @builder.placeholder}
       >
       </span>
       <span class="h-4 w-4 opacity-50" />
@@ -99,7 +103,7 @@ defmodule SaladUI.Select do
     """
   end
 
-  attr :instance, :map, required: true, doc: "The instance of the select component"
+  attr :builder, :map, required: true, doc: "The builder of the select component"
 
   attr :class, :string, default: nil
   attr :side, :string, values: ~w(top bottom), default: "bottom"
@@ -117,7 +121,7 @@ defmodule SaladUI.Select do
     assigns =
       assigns
       |> assign(:position_class, position_class)
-      |> assign(:id, assigns.instance.id <> "-content")
+      |> assign(:id, assigns.builder.id <> "-content")
 
     ~H"""
     <.focus_wrap
@@ -164,7 +168,7 @@ defmodule SaladUI.Select do
     """
   end
 
-  attr :instance, :map, required: true, doc: "The instance of the select component"
+  attr :builder, :map, required: true, doc: "The builder of the select component"
 
   attr :value, :string, required: true
   attr :label, :string, default: nil
@@ -188,18 +192,18 @@ defmodule SaladUI.Select do
         ])
       }
       {%{"data-disabled": @disabled}}
-      phx-click={select_value(@instance.id, @label)}
+      phx-click={select_value(@builder.id, @label)}
       {@rest}
     >
       <input
         type="radio"
         class="peer w-0 opacity-0"
-        name={@instance.name}
+        name={@builder.name}
         value={@value}
-        checked={@instance.value == @value}
+        checked={@builder.value == @value}
         disabled={@disabled}
         phx-key="Escape"
-        phx-keydown={JS.exec("x-hide-select", to: "##{@instance.id}")}
+        phx-keydown={JS.exec("x-hide-select", to: "##{@builder.id}")}
       />
       <div class="absolute top-0 left-0 w-full h-full group-hover/item:bg-accent rounded"></div>
       <span class="hidden peer-checked:block absolute left-2 flex h-3.5 w-3.5 items-center justify-center">

--- a/lib/salad_ui/slider.ex
+++ b/lib/salad_ui/slider.ex
@@ -13,13 +13,20 @@ defmodule SaladUI.Slider do
   """
   attr :id, :string, required: true
   attr :class, :string, default: nil
+  attr :name, :string, default: nil
   attr :value, :integer, default: 0, doc: ""
+  attr :"default-value", :integer
+  attr :field, Phoenix.HTML.FormField, doc: "a form field struct retrieved from the form, for example: @form[:email]"
+
   attr :min, :integer, default: 0
   attr :max, :integer, default: 100
   attr :step, :integer, default: 1
   attr :rest, :global
 
   def slider(assigns) do
+    assigns =
+      prepare_assign(assigns)
+
     assigns =
       assigns
       |> Map.put(:value, normalize_integer(assigns[:value]))
@@ -60,14 +67,10 @@ defmodule SaladUI.Slider do
       <input
         type="range"
         class="absolute top-0 -left-2 z-1 w-full appearance-none cursor-pointer opacity-0"
-        min={@min}
-        max={@max}
-        value={@value}
-        step={@step}
-        id={@id}
         phx-update="ignore"
         style="width: calc(100% + 20px)"
-        oninput={"this.parentNode.style='--#{@id}-val:' + (this.value - #{@min})/#{@max - @min}*100"}
+        oninput={"this.parentNode.style='--#{@id}-val:' + (this.value - #{@min})/#{@max - @min}*100; return true;"}
+        {%{min: @min, max: @max, value: @value, step: @step, id: @id, name: @name}}
         {@rest}
       />
     </div>

--- a/lib/salad_ui/switch.ex
+++ b/lib/salad_ui/switch.ex
@@ -10,14 +10,20 @@ defmodule SaladUI.Switch do
   """
   attr :id, :string, required: true
   attr :name, :string, default: nil
-  attr :checked, :string, default: "false"
+  attr :value, :boolean, default: nil
+  attr :field, Phoenix.HTML.FormField, doc: "a form field struct retrieved from the form, for example: @form[:email]"
+
+  attr :"default-value", :any, values: [true, false, "true", "false"], default: false
   attr :class, :string, default: nil
   attr :disabled, :boolean, default: false
   attr :rest, :global
 
   def switch(assigns) do
     assigns =
-      assign(assigns, :checked, Phoenix.HTML.Form.normalize_value("checkbox", assigns.checked))
+      prepare_assign(assigns)
+
+    assigns =
+      assign(assigns, :checked, Phoenix.HTML.Form.normalize_value("checkbox", assigns.value))
 
     ~H"""
     <button
@@ -36,14 +42,7 @@ defmodule SaladUI.Switch do
       <span class="pointer-events-none block h-5 w-5 rounded-full bg-background shadow-lg ring-0 transition-transform group-data-[state=checked]/switch:translate-x-5 group-data-[state=unchecked]/switch:translate-x-0">
       </span>
       <input type="hidden" name={@name} value="false" />
-      <input
-        type="checkbox"
-        class="hidden"
-        name={@name}
-        value="true"
-        {%{checked: @checked && "true"}}
-        {@rest}
-      />
+      <input type="checkbox" class="hidden" name={@name} value="true" {%{checked: @checked}} {@rest} />
     </button>
     """
   end

--- a/lib/salad_ui/tabs.ex
+++ b/lib/salad_ui/tabs.ex
@@ -5,19 +5,19 @@ defmodule SaladUI.Tabs do
 
   ## Example:
 
-      <.tabs default="account" id="settings" class="w-[400px]">
+      <.tabs default="account" id="settings" :let={builder} class="w-[400px]">
       <.tabs_list class="grid w-full grid-cols-2">
-        <.tabs_trigger root="settings" target="account">account</.tabs_trigger>
-        <.tabs_trigger root="settings" target="password">password</.tabs_trigger>
+        <.tabs_trigger builder={builder} value="account">account</.tabs_trigger>
+        <.tabs_trigger builder={builder} value="password">password</.tabs_trigger>
       </.tabs_list>
-      <.tabs_content id="account">
+      <.tabs_content value="account">
           <.card>
           <.card_content class="p-6">
             Account
           </.card_content>
         </.card>
       </.tabs_content>
-      <.tabs_content id="password">
+      <.tabs_content value="password">
         <.card>
           <.card_content class="p-6">
             Password
@@ -35,9 +35,11 @@ defmodule SaladUI.Tabs do
   attr :rest, :global
 
   def tabs(assigns) do
+    assigns = assign(assigns, :builder, %{default: assigns.default, id: assigns.id})
+
     ~H"""
     <div class={@class} id={@id} {@rest} phx-mounted={show_tab(@id, @default)}>
-      <%= render_slot(@inner_block) %>
+      <%= render_slot(@inner_block, @builder) %>
     </div>
     """
   end
@@ -62,7 +64,7 @@ defmodule SaladUI.Tabs do
     """
   end
 
-  attr :root, :string, required: true, doc: "id of root tabs tag"
+  attr :builder, :map, required: true, doc: "builder instance of tabs"
   attr :value, :string, required: true, doc: "target value of tab content"
   attr :class, :string, default: nil
   slot :inner_block, required: true
@@ -79,7 +81,7 @@ defmodule SaladUI.Tabs do
         ])
       }
       data-target={@value}
-      phx-click={show_tab(@root, @value)}
+      phx-click={show_tab(@builder.id, @value)}
       {@rest}
     >
       <%= render_slot(@inner_block) %>

--- a/lib/salad_ui/toggle.ex
+++ b/lib/salad_ui/toggle.ex
@@ -7,11 +7,15 @@ defmodule SaladUI.Toggle do
 
   ## Example:
 
-      <.toggle pressed="true" size="sm" variant="outline">Bold</.toggle>
+      <.toggle value="true" size="sm" variant="outline">Bold</.toggle>
   """
   attr :id, :any, default: nil
   attr :name, :any, default: nil
-  attr :pressed, :boolean, default: false
+  attr :field, Phoenix.HTML.FormField, doc: "a form field struct retrieved from the form, for example: @form[:email]"
+
+  attr :value, :boolean, default: false
+  attr :"default-value", :any, values: [true, false, "true", "false"], default: false
+
   attr :disabled, :boolean, default: false
   attr :variant, :string, values: ~w(default outline), default: "default"
   attr :size, :string, values: ~w(default sm lg), default: "default"
@@ -21,8 +25,11 @@ defmodule SaladUI.Toggle do
 
   def toggle(assigns) do
     assigns =
+      prepare_assign(assigns)
+
+    assigns =
       assigns
-      |> assign_new(:checked, fn -> Phoenix.HTML.Form.normalize_value("checkbox", assigns.pressed) end)
+      |> assign_new(:checked, fn -> Phoenix.HTML.Form.normalize_value("checkbox", assigns.value) end)
       |> assign(:variant_class, variant(assigns))
 
     ~H"""
@@ -41,7 +48,7 @@ defmodule SaladUI.Toggle do
       <input
         type="checkbox"
         class="toggle-input hidden"
-        id={@id || @name}
+        id={@id}
         name={@name}
         value="true"
         checked={@checked}


### PR DESCRIPTION
- Support Form.Field and default-value for all input components
- unify term `builder` for following components
  - `select`: `instance` --> `builder`
  - `tab`: `root` --> `builder`

## Summary by Sourcery

Refactor input components to support Form.Field and default-value attributes, unify terminology across components, and enhance component logic for better state management and default value handling.

Enhancements:
- Refactor input components to support Form.Field and default-value attributes across all input components.
- Unify the terminology by replacing 'instance' with 'builder' in select components and 'root' with 'builder' in tab components.
- Improve the toggle group component by changing the handling of single and multiple selection types, including adjustments to the input type and checked state logic.
- Enhance the select component by introducing a builder pattern and supporting default values.
- Refactor the switch component to use a value attribute instead of checked, and support default values.
- Update the tabs component to use a builder pattern for managing tab states.
- Refactor the slider component to support default values and improve value normalization.
- Enhance the toggle component by replacing the pressed attribute with a value attribute and supporting default values.
- Refactor the checkbox component to support default values and improve checked state handling.
- Update the input component to support default values and improve attribute merging logic.
- Enhance the radio group component by supporting default values and using a builder pattern.