### PR TITLE
Support input name override and other attrs like required

### DIFF
--- a/lib/salad_ui/helpers.ex
+++ b/lib/salad_ui/helpers.ex
@@ -9,8 +9,8 @@ defmodule SaladUI.Helpers do
     assigns
     |> assign(field: nil, id: assigns[:id] || field.id)
     # |> assign(:errors, Enum.map(field.errors, &translate_error(&1)))
-    |> assign(:name, if(assigns[:multiple], do: field.name <> "[]", else: field.name))
-    |> assign(:value, field.value)
+    |> assign_new(:name, fn -> if(assigns[:multiple], do: field.name <> "[]", else: field.name) end)
+    |> assign_new(:value, fn -> field.value end)
     |> prepare_assign()
   end
 

--- a/lib/salad_ui/input.ex
+++ b/lib/salad_ui/input.ex
@@ -12,7 +12,7 @@ defmodule SaladUI.Input do
       <.input type="password" placeholder="Enter your password" />
   """
   attr :id, :any, default: nil
-  attr :name, :any, default: nil
+  attr :name, :any
   attr :value, :any
 
   attr :type, :string,
@@ -24,7 +24,9 @@ defmodule SaladUI.Input do
   attr :field, Phoenix.HTML.FormField, doc: "a form field struct retrieved from the form, for example: @form[:email]"
 
   attr :class, :string, default: nil
-  attr :rest, :global
+  attr :rest, :global,
+    include: ~w(accept autocomplete capture cols disabled form list max maxlength min minlength
+                multiple pattern placeholder readonly required rows size step)
 
   def input(assigns) do
     assigns = prepare_assign(assigns)

--- a/test/salad_ui/input_test.exs
+++ b/test/salad_ui/input_test.exs
@@ -101,5 +101,51 @@ defmodule SaladUI.InputTest do
       assert html =~
                "<input class=\"flex px-3 py-2 rounded-md ring-offset-background border-input bg-background text-sm w-full h-10 placeholder:text-muted-foreground disabled:cursor-not-allowed disabled:opacity-50 focus-visible:ring-ring focus-visible:outline-none focus-visible:ring-2 focus-visible:ring-offset-2 file:border-0 file:bg-transparent file:font-medium file:text-sm border\" name=\"secret\" type=\"hidden\" value=\"hard to get in\">"
     end
+
+    test "It sets the id and name when only given a form field" do
+      assigns = %{form: %{
+        email: %Phoenix.HTML.FormField{
+          id: "user_email",
+          name: "user[email]",
+          errors: [],
+          field: :email,
+          value: nil,
+          form: nil
+        }
+      }}
+
+      html =
+        ~H"""
+        <.input field={@form[:email]} required />
+        """
+        |> rendered_to_string()
+        |> clean_string()
+
+      assert html =~
+               "<input class=\"flex px-3 py-2 rounded-md ring-offset-background border-input bg-background text-sm w-full h-10 placeholder:text-muted-foreground disabled:cursor-not-allowed disabled:opacity-50 focus-visible:ring-ring focus-visible:outline-none focus-visible:ring-2 focus-visible:ring-offset-2 file:border-0 file:bg-transparent file:font-medium file:text-sm border\" id=\"user_email\" name=\"user[email]\" type=\"text\" required>"
+    end
+
+    test "It supports overriding the form field id and name when explicitly set" do
+      assigns = %{form: %{
+        email: %Phoenix.HTML.FormField{
+          id: "user_email",
+          name: "user[email]",
+          errors: [],
+          field: :email,
+          value: nil,
+          form: nil
+        }
+      }}
+
+      html =
+        ~H"""
+        <.input id="custom" name="custom" field={@form[:email]} required />
+        """
+        |> rendered_to_string()
+        |> clean_string()
+
+      assert html =~
+               "<input class=\"flex px-3 py-2 rounded-md ring-offset-background border-input bg-background text-sm w-full h-10 placeholder:text-muted-foreground disabled:cursor-not-allowed disabled:opacity-50 focus-visible:ring-ring focus-visible:outline-none focus-visible:ring-2 focus-visible:ring-offset-2 file:border-0 file:bg-transparent file:font-medium file:text-sm border\" id=\"custom\" name=\"custom\" type=\"text\" required>"
+    end
   end
 end


### PR DESCRIPTION
Noticed a few things when I was building out some forms.

## Summary by Sourcery

Enhance the SaladUI.Input module to support input name overrides and additional HTML attributes, improving form customization capabilities.

New Features:
- Allow overriding the input name attribute in the SaladUI.Input module.

Enhancements:
- Add support for additional HTML attributes such as 'required', 'autocomplete', and 'maxlength' in the SaladUI.Input module.