### PR TITLE
Add support for custom error translation function

### DIFF
--- a/README.md
+++ b/README.md
@@ -147,6 +147,12 @@ body {
     }
 ```
 
+7. Config custom error translate function
+
+```elixir
+config :salad_ui, :error_translator_function, {MyAppWeb.CoreComponents, :translate_error}
+```
+
 ## Development
 
 Here is how to start develop SaladUI on local machine.
@@ -211,3 +217,13 @@ To run the failing tests only, just run `mix test.watch --stale`.
 - ✅ Tooltip
 - ✅ Toggle
 - ✅ Toggle Group
+
+
+## Credits
+This project could not be available without these awesome works:
+
+- `tailwind css` an awesome css utility project
+- `tails` for merging tailwind class
+- `shadcn/ui` which this project is inspired from
+- `Phoenix Framework` of course
+

--- a/lib/salad_ui/helpers.ex
+++ b/lib/salad_ui/helpers.ex
@@ -8,7 +8,7 @@ defmodule SaladUI.Helpers do
   def prepare_assign(%{field: %Phoenix.HTML.FormField{} = field} = assigns) do
     assigns
     |> assign(field: nil, id: assigns[:id] || field.id)
-    # |> assign(:errors, Enum.map(field.errors, &translate_error(&1)))
+    |> assign(:errors, Enum.map(field.errors, &translate_error(&1)))
     |> assign(:name, if(assigns[:multiple], do: field.name <> "[]", else: field.name))
     |> assign(:value, field.value)
     |> prepare_assign()

--- a/lib/salad_ui/helpers.ex
+++ b/lib/salad_ui/helpers.ex
@@ -119,12 +119,9 @@ defmodule SaladUI.Helpers do
   end
 
   defp get_translator_from_config do
-    case_result =
-      case Application.get_env(:salad_ui, :error_translator_function) do
-        {module, function} -> &apply(module, function, [&1])
-        nil -> nil
-      end
-
-    IO.inspect(case_result, label: "error_translator_function")
+    case Application.get_env(:salad_ui, :error_translator_function) do
+      {module, function} -> &apply(module, function, [&1])
+      nil -> nil
+    end
   end
 end


### PR DESCRIPTION
I borrow some code from petal  for this

add following config to customize error translate function

```elixir
config :salad_ui, :error_translator_function, {MyAppWeb.CoreComponents, :translate_error}
```

## Summary by Sourcery

Add support for a custom error translation function, allowing users to specify their own translation logic through configuration. Refactor form components to leverage this new feature, enhancing error message customization. Update documentation to guide users on setting up the custom error translation.

New Features:
- Introduce support for a custom error translation function, allowing users to configure their own error translation logic via the `:error_translator_function` configuration.

Enhancements:
- Refactor error handling in form components to utilize the new custom error translation function, improving flexibility in error message customization.

Documentation:
- Update README.md to include instructions on configuring a custom error translation function.