### PR TITLE
CLI to setup the library and add components

### DIFF
--- a/lib/mix/tasks/salad.add.ex
+++ b/lib/mix/tasks/salad.add.ex
@@ -88,7 +88,10 @@ defmodule Mix.Tasks.Salad.Add do
 
   defp insert_target_module_name(source) do
     module_name = get_module_name()
-    Regex.replace(~r/defmodule SaladUI\.([a-zA-Z0-9_]+)/, source, "defmodule #{module_name}.Components.\\1")
+
+    source
+    |> String.replace(~r/defmodule SaladUI\.([a-zA-Z0-9_]+)/, "defmodule #{module_name}.Components.\\1")
+    |> String.replace(~r/use SaladUI,\s*:component/, "use #{module_name}.Component")
   end
 
   defp get_module_name do

--- a/lib/mix/tasks/salad.add.ex
+++ b/lib/mix/tasks/salad.add.ex
@@ -1,0 +1,157 @@
+defmodule Mix.Tasks.Salad.Add do
+  @moduledoc """
+  A Mix task for adding Salad UI components to your project.
+
+  Usage:
+    mix salad.add [component_name]
+    mix salad.add all
+    mix salad.add help
+  """
+  use Mix.Task
+
+  @non_components_files ~w(patcher helper)
+
+  @impl true
+  def run(argv) do
+    available_components = list_available_components()
+
+    case argv do
+      ["help"] ->
+        print_usage_and_components(available_components)
+
+      ["all"] ->
+        install_components(available_components)
+
+      components when is_list(components) and length(components) > 0 ->
+        handle_component_installation(components, available_components)
+
+      _ ->
+        print_usage_and_components(available_components)
+    end
+  end
+
+  defp handle_component_installation(components, available_components) do
+    {valid, invalid} = Enum.split_with(components, &(&1 in available_components))
+
+    case {valid, invalid} do
+      {_, []} ->
+        install_components(valid)
+
+      {[], _} ->
+        report_invalid_components(invalid)
+
+      {_, _} ->
+        report_invalid_components(invalid)
+        prompt_for_valid_component_installation(valid)
+    end
+  end
+
+  defp prompt_for_valid_component_installation(valid_components) do
+    report_valid_components(valid_components)
+
+    if Mix.shell().yes?("Do you want to install the valid component(s)?") do
+      install_components(valid_components)
+    end
+  end
+
+  defp install_components(components) do
+    Enum.each(components, &install_component/1)
+  end
+
+  defp install_component(file_name) do
+    with {:ok, source_file} <- build_source_file_path(file_name),
+         {:ok, source_content} <- File.read(source_file),
+         target_path = build_target_file_path(file_name),
+         :ok <- File.mkdir_p(Path.dirname(target_path)),
+         modified_content = insert_target_module_name(source_content),
+         :ok <- File.write(target_path, modified_content) do
+      Mix.shell().info("#{file_name} component installed successfully ✅")
+    else
+      {:error, :source_not_found} ->
+        Mix.shell().error("Template not found: #{file_name}")
+
+      {:error, reason} ->
+        Mix.shell().error("Failed to install #{file_name}: #{inspect(reason)}")
+    end
+  end
+
+  defp build_source_file_path(file_name) do
+    path = Path.join([get_base_path(), "#{file_name}.ex"])
+    if File.exists?(path), do: {:ok, path}, else: {:error, :source_not_found}
+  end
+
+  defp build_target_file_path(file_name) do
+    Path.join([component_dir(), "#{file_name}.ex"])
+  end
+
+  defp insert_target_module_name(source) do
+    module_name = get_module_name()
+    Regex.replace(~r/defmodule SaladUI\.([a-zA-Z0-9_]+)/, source, "defmodule #{module_name}.Components.\\1")
+  end
+
+  defp get_module_name do
+    Mix.Project.config()[:app]
+    |> Atom.to_string()
+    |> Macro.camelize()
+    |> Kernel.<>("Web")
+  end
+
+  defp component_dir do
+    Application.get_env(:salad_ui, :components_path)
+  end
+
+  defp print_usage_and_components(available_components) do
+    Mix.shell().info(@moduledoc)
+    Mix.shell().info("\nAvailable components:\n#{Enum.join(available_components, "\n")}")
+  end
+
+  defp list_available_components do
+    if Mix.env() == :test do
+      # In test, mock the list of available components
+      ["button", "card", "input"]
+    else
+      get_base_path()
+      |> Path.join("*.ex")
+      |> Path.wildcard()
+      |> Enum.map(&Path.basename(&1, ".ex"))
+      |> Enum.reject(&(&1 in @non_components_files))
+    end
+  end
+
+  defp get_base_path do
+    if Mix.env() == :test do
+      # In test, we do not have access to the salad_ui dependency
+      # so we need to find the components source files under the `lib/salad_ui` directory
+      Path.expand("lib/salad_ui")
+    else
+      case find_salad_ui_dep() do
+        {:ok, path} -> path |> Path.join("lib/salad_ui") |> Path.expand()
+        {:error, reason} -> raise "Failed to find SaladUI: #{reason}"
+      end
+    end
+  end
+
+  defp find_salad_ui_dep do
+    deps = Mix.Dep.load_and_cache()
+
+    case Enum.find(deps, &(&1.app == :salad_ui)) do
+      %Mix.Dep{opts: opts} = dep ->
+        if path = Keyword.get(opts, :path) do
+          {:ok, path}
+        else
+          {:ok, Path.join([File.cwd!(), "deps", Atom.to_string(dep.app)])}
+        end
+
+      nil ->
+        {:error, "SaladUI not found in dependencies"}
+    end
+  end
+
+  defp report_invalid_components(invalid) do
+    Mix.shell().error("Invalid components:\n#{Enum.join(invalid, "\n")}")
+  end
+
+  defp report_valid_components(valid) do
+    Mix.shell().info("Valid components:\n#{Enum.join(valid, "\n")}")
+  end
+end

--- a/lib/mix/tasks/salad.add.ex
+++ b/lib/mix/tasks/salad.add.ex
@@ -9,7 +9,9 @@ defmodule Mix.Tasks.Salad.Add do
   """
   use Mix.Task
 
-  @non_components_files ~w(patcher helper)
+  import SaladUi.TasksHelpers
+
+  @non_components_files ~w(patcher helper task_helpers)
 
   @impl true
   def run(argv) do
@@ -115,35 +117,6 @@ defmodule Mix.Tasks.Salad.Add do
       |> Path.wildcard()
       |> Enum.map(&Path.basename(&1, ".ex"))
       |> Enum.reject(&(&1 in @non_components_files))
-    end
-  end
-
-  defp get_base_path do
-    if Mix.env() == :test do
-      # In test, we do not have access to the salad_ui dependency
-      # so we need to find the components source files under the `lib/salad_ui` directory
-      Path.expand("lib/salad_ui")
-    else
-      case find_salad_ui_dep() do
-        {:ok, path} -> path |> Path.join("lib/salad_ui") |> Path.expand()
-        {:error, reason} -> raise "Failed to find SaladUI: #{reason}"
-      end
-    end
-  end
-
-  defp find_salad_ui_dep do
-    deps = Mix.Dep.load_and_cache()
-
-    case Enum.find(deps, &(&1.app == :salad_ui)) do
-      %Mix.Dep{opts: opts} = dep ->
-        if path = Keyword.get(opts, :path) do
-          {:ok, path}
-        else
-          {:ok, Path.join([File.cwd!(), "deps", Atom.to_string(dep.app)])}
-        end
-
-      nil ->
-        {:error, "SaladUI not found in dependencies"}
     end
   end
 

--- a/lib/mix/tasks/salad.init.ex
+++ b/lib/mix/tasks/salad.init.ex
@@ -6,6 +6,8 @@ defmodule Mix.Tasks.Salad.Init do
   """
   use Mix.Task
 
+  import SaladUi.TasksHelpers
+
   alias SaladUI.Patcher
 
   @default_components_path "lib/%APP_NAME%_web/components/ui"

--- a/lib/mix/tasks/salad.init.ex
+++ b/lib/mix/tasks/salad.init.ex
@@ -1,0 +1,173 @@
+defmodule Mix.Tasks.Salad.Init do
+  @moduledoc """
+  A Mix task for initializing SaladUI in a project and configuring it to use a color theme.
+
+  Usage: mix salad.init
+  """
+  use Mix.Task
+
+  alias SaladUI.Patcher
+
+  @default_components_path "lib/%APP_NAME%_web/components/ui"
+  @color_schemes ~w(zinc slate stone gray neutral red rose orange green blue yellow violet)
+  @default_color_scheme "gray"
+
+  @impl true
+  def run(argv) do
+    case argv do
+      ["help"] -> print_usage()
+      _ -> execute_init()
+    end
+  end
+
+  defp execute_init do
+    component_path = prompt_component_path()
+    color_scheme = prompt_color_scheme()
+    init(component_path, color_scheme)
+  end
+
+  defp init(component_path, color_scheme) do
+    env = Atom.to_string(Mix.env())
+    assets_path = build_assets_path(env)
+
+    node_opts = if env == "test", do: [skip: true], else: []
+
+    File.mkdir_p!(component_path)
+
+    with :ok <- write_config(component_path),
+         :ok <- patch_css(color_scheme, assets_path),
+         :ok <- patch_js(assets_path),
+         :ok <- copy_tailwind_colors(assets_path),
+         :ok <- patch_tailwind_config(),
+         :ok <- install_node_dependencies(node_opts) do
+      Mix.shell().info("Done. Now you can add components by running mix salad.add <component_name>")
+    else
+      {:error, reason} -> Mix.shell().error("Error during setup: #{reason}")
+    end
+  end
+
+  defp prompt_component_path do
+    default_path = build_default_component_path()
+
+    "Enter the path to the components folder (#{default_path}):"
+    |> Mix.shell().prompt()
+    |> String.trim()
+    |> case do
+      "" -> default_path
+      path -> parse_path(path)
+    end
+  end
+
+  defp prompt_color_scheme do
+    prompt = "Select the color scheme to use (#{@default_color_scheme}):"
+    response = prompt |> Mix.shell().prompt() |> String.trim() |> String.downcase()
+
+    case response do
+      "" ->
+        Mix.shell().info("Using default color scheme: #{@default_color_scheme}")
+        @default_color_scheme
+
+      color_scheme when color_scheme in @color_schemes ->
+        Mix.shell().info("Using color scheme: #{color_scheme}")
+        color_scheme
+
+      _ ->
+        Mix.shell().error("Invalid color scheme")
+        prompt_color_scheme()
+    end
+  end
+
+  defp write_config(component_path) do
+    Mix.shell().info("Writing components path to config.exs")
+    config_path = Path.join(File.cwd!(), "config/config.exs")
+
+    if File.exists?(config_path) do
+      Patcher.patch_config(config_path, component_path)
+      :ok
+    else
+      {:error, "config.exs not found"}
+    end
+  end
+
+  defp patch_css(color_scheme, assets_path) do
+    app_css_path = Path.join(File.cwd!(), "assets/css/app.css")
+    css_color_scheme_path = Path.join([assets_path, "colors", "#{color_scheme}.css"])
+
+    if File.exists?(app_css_path) do
+      Mix.shell().info("Patching app.css")
+      Patcher.patch_css_file(app_css_path, css_color_scheme_path)
+      :ok
+    else
+      {:error, "app.css not found"}
+    end
+  end
+
+  defp patch_js(assets_path) do
+    app_js_path = Path.join(File.cwd!(), "assets/js/app.js")
+    js_file_path = Path.join(assets_path, "server-events.js")
+
+    if File.exists?(app_js_path) do
+      Mix.shell().info("Patching app.js")
+      Patcher.patch_js_file(app_js_path, js_file_path)
+      :ok
+    else
+      {:error, "app.js not found"}
+    end
+  end
+
+  defp copy_tailwind_colors(assets_path) do
+    Mix.shell().info("Copying tailwind.colors.json to assets folder")
+    source_path = Path.join(assets_path, "tailwind.colors.json")
+    target_path = Path.join(File.cwd!(), "assets/tailwind.colors.json")
+
+    unless File.exists?(target_path) do
+      File.cp!(source_path, target_path)
+    end
+
+    :ok
+  end
+
+  defp patch_tailwind_config do
+    Mix.shell().info("Patching tailwind.config.js")
+    tailwind_config_path = Path.join(File.cwd!(), "assets/tailwind.config.js")
+
+    if File.exists?(tailwind_config_path) do
+      Patcher.patch_tailwind_config(tailwind_config_path)
+      :ok
+    else
+      {:error, "tailwind.config.js not found"}
+    end
+  end
+
+  defp install_node_dependencies(opts) do
+    if Keyword.get(opts, :skip, false) do
+      Mix.shell().info("Skipping npm install (running in test environment)")
+    else
+      Mix.shell().info("Installing tailwindcss-animate")
+      Mix.shell().cmd("npm install -D tailwindcss-animate --prefix assets")
+    end
+
+    :ok
+  end
+
+  defp print_usage, do: Mix.shell().info(@moduledoc)
+
+  defp parse_path(path) do
+    path
+    # remove trailing slash
+    |> String.replace(~r/\/$/, "")
+    # remove leading slash
+    |> String.replace(~r/^\.*\/?/, "")
+  end
+
+  defp build_assets_path(env) do
+    ["_build", env, "lib/salad_ui/priv/static/assets"]
+    |> Path.join()
+    |> Path.expand()
+  end
+
+  defp build_default_component_path do
+    app_name = Mix.Project.config()[:app] |> Atom.to_string() |> String.downcase()
+    String.replace(@default_components_path, "%APP_NAME%", app_name)
+  end
+end

--- a/lib/salad_ui/patcher.ex
+++ b/lib/salad_ui/patcher.ex
@@ -1,0 +1,65 @@
+defmodule SaladUI.Patcher do
+  @moduledoc """
+  Provides functionality to patch various configuration and source files in Phoenix projects.
+
+  This module is intended to be used by the CLI during the installation of `SaladUI` in a project.
+  It handles patching of config files, Tailwind CSS configuration, CSS files, and JavaScript files.
+  """
+
+  alias SaladUI.Patcher.ConfigPatcher
+  alias SaladUI.Patcher.CSSPatcher
+  alias SaladUI.Patcher.JSPatcher
+  alias SaladUI.Patcher.TailwindPatcher
+
+  @doc """
+  Patches the Elixir project configuration file.
+
+  Adds new configuration to the existing config file without modifying or removing previous content.
+
+  ## Parameters
+
+  - config_path: The path to the project's `config.exs` file
+  - components_path: The path to the components directory
+  """
+  def patch_config(config_path, components_path) do
+    ConfigPatcher.patch(config_path, components_path)
+  end
+
+  @doc """
+  Patches the Tailwind CSS configuration in a Phoenix project.
+
+  Adds required plugins to the Tailwind configuration and extends the theme configuration to use a JSON file that enables theming via CSS variables, without modifying existing user configuration.
+
+  ## Parameters
+
+  - tailwind_config_path: Path to the Tailwind configuration file
+  """
+  def patch_tailwind_config(tailwind_config_path) do
+    TailwindPatcher.patch(tailwind_config_path)
+  end
+
+  @doc """
+  Patches a CSS file by adding all variables needed for a color scheme.
+  Also adds optional tweaks to the CSS file.
+
+  ## Parameters
+
+  - css_file_path: Path to the CSS file
+  - color_scheme_file_path: Path to the file containing the color scheme CSS code
+  """
+  def patch_css_file(css_file_path, color_scheme_file_path) do
+    CSSPatcher.patch(css_file_path, color_scheme_file_path)
+  end
+
+  @doc """
+  Patches a JavaScript file by adding JS code snippet to handle events from the server.
+
+  ## Parameters
+
+  - js_file_path: Path to the JavaScript file
+  - code_to_add_file_path: Path to the file containing the JS code to be added
+  """
+  def patch_js_file(js_file_path, code_to_add_file_path) do
+    JSPatcher.patch(js_file_path, code_to_add_file_path)
+  end
+end

--- a/lib/salad_ui/patcher.ex
+++ b/lib/salad_ui/patcher.ex
@@ -19,10 +19,10 @@ defmodule SaladUI.Patcher do
   ## Parameters
 
   - config_path: The path to the project's `config.exs` file
-  - components_path: The path to the components directory
+  - configs: A list of configurations to add to the config file. Each configuration must be a tuple with the name of the configuration and a map with the description and values to add. If you want to insert Elixir code, suchs as modules or an expression, use a string with the code you want to insert.
   """
-  def patch_config(config_path, components_path) do
-    ConfigPatcher.patch(config_path, components_path)
+  def patch_config(config_path, configs) do
+    ConfigPatcher.patch(config_path, configs: configs)
   end
 
   @doc """

--- a/lib/salad_ui/patcher/config_patcher.ex
+++ b/lib/salad_ui/patcher/config_patcher.ex
@@ -1,0 +1,109 @@
+defmodule SaladUI.Patcher.ConfigPatcher do
+  @moduledoc false
+
+  def patch(config_path, components_path) do
+    new_content =
+      config_path
+      |> File.read!()
+      |> update_content(components_path)
+
+    File.write!(config_path, new_content)
+  end
+
+  defp update_content(content, components_path) do
+    content
+    |> add_config_if_missing(
+      :salad_ui,
+      "Path to install SaladUI components",
+      components_path: "Path.join(File.cwd!(), \"#{components_path}\")"
+    )
+    |> add_config_if_missing(
+      :tails,
+      "SaladUI use tails to properly merge Tailwind CSS classes",
+      colors_file: "Path.join(File.cwd!(), \"assets/tailwind.colors.json\")"
+    )
+  end
+
+  defp add_config_if_missing(content, config_name, description, values) do
+    if config_exists?(content, config_name, values) do
+      content
+    else
+      insert_config(content, build_config(config_name, description, values))
+    end
+  end
+
+  defp config_exists?(content, config_name, values) do
+    Enum.any?(values, fn
+      {key, _value} ->
+        normalized_contains?(content, "config :#{config_name}, #{key}:")
+
+      key when is_atom(key) ->
+        normalized_contains?(content, "config :#{config_name}, #{key}")
+
+      _ ->
+        false
+    end)
+  end
+
+  defp build_config(config_name, description, values) do
+    formatted_values = format_values(values)
+
+    """
+    # #{description}
+    config :#{config_name}, #{formatted_values}
+    """
+  end
+
+  # If you want to insert Elixir code, suchs as modules
+  # or an expression, using a string with the code you want to insert
+  defp format_values(values) do
+    Enum.map_join(values, ", ", fn
+      {key, value} -> "#{key}: #{value}"
+      key -> key
+    end)
+  end
+
+  defp insert_config(content, config) do
+    case find_import_config_position(content) do
+      {:ok, position} -> insert_before_import(content, config, position)
+      :error -> append_config(content, config)
+    end
+  end
+
+  defp find_import_config_position(content) do
+    import_config_regex = ~r/(\n\s*(#[^\n]*\n\s*)*)?import_config.*$/s
+
+    case Regex.run(import_config_regex, content, return: :index) do
+      [{start_index, _} | _] -> {:ok, start_index}
+      nil -> :error
+    end
+  end
+
+  defp insert_before_import(content, config, position) do
+    {before_import, import_section} = String.split_at(content, position)
+
+    before_import
+    |> String.trim_trailing()
+    |> Kernel.<>("\n\n#{config}\n#{String.trim_leading(import_section)}")
+  end
+
+  defp append_config(content, config) do
+    content
+    |> String.trim_trailing()
+    |> Kernel.<>("\n\n#{config}")
+  end
+
+  # Check if a string contains a pattern, ignoring case and spaces
+  defp normalized_contains?(content, pattern) do
+    normalized_content = normalize(content)
+    normalized_pattern = normalize(pattern)
+
+    String.contains?(normalized_content, normalized_pattern)
+  end
+
+  defp normalize(input) when is_binary(input) do
+    input
+    |> String.downcase()
+    |> String.replace(~r/[^a-z0-9]/, "")
+  end
+end

--- a/lib/salad_ui/patcher/css_patcher.ex
+++ b/lib/salad_ui/patcher/css_patcher.ex
@@ -1,0 +1,45 @@
+defmodule SaladUI.Patcher.CSSPatcher do
+  @moduledoc false
+
+  # When used in body, ensures dark and light mode work correctly
+  @body_tweak "@apply bg-background text-foreground;"
+
+  def patch(css_file_path, color_scheme_file_path) do
+    color_scheme_code = File.read!(color_scheme_file_path)
+
+    new_content =
+      css_file_path
+      |> File.read!()
+      |> update_content(color_scheme_code)
+
+    File.write!(css_file_path, new_content)
+  end
+
+  defp update_content(content, color_scheme_code) do
+    content
+    |> add_color_scheme(color_scheme_code)
+    |> add_css_tweaks()
+  end
+
+  defp add_color_scheme(content, color_scheme_code) do
+    new_base_layer = """
+    @layer base {
+      #{color_scheme_code}
+      * {
+        @apply border-border !important;
+      }
+    }\n
+    """
+
+    content <> "\n\n" <> new_base_layer
+  end
+
+  defp add_css_tweaks(content) do
+    to_insert = """
+    body { #{@body_tweak} }
+    """
+
+    # Add the tweaks at the bottom of the file
+    content <> to_insert
+  end
+end

--- a/lib/salad_ui/patcher/js_patcher.ex
+++ b/lib/salad_ui/patcher/js_patcher.ex
@@ -1,0 +1,21 @@
+defmodule SaladUI.Patcher.JSPatcher do
+  @moduledoc false
+  def patch(js_file_path, code_to_add_file_path) do
+    code_to_add = File.read!(code_to_add_file_path)
+
+    new_content =
+      js_file_path
+      |> File.read!()
+      |> update_content(code_to_add)
+
+    File.write!(js_file_path, new_content)
+  end
+
+  defp update_content(content, code_to_add) do
+    if String.contains?(content, code_to_add) do
+      content
+    else
+      content <> "\n" <> "// Allows to execute JS commands from the server\n" <> code_to_add
+    end
+  end
+end

--- a/lib/salad_ui/patcher/tailwind_patcher.ex
+++ b/lib/salad_ui/patcher/tailwind_patcher.ex
@@ -1,0 +1,125 @@
+defmodule SaladUI.Patcher.TailwindPatcher do
+  @moduledoc false
+
+  # TODO: Improve the formatting of the generated code,
+  # so the user does not to manually format his `tailwind.config.js`
+  # file after patching it.
+
+  @plugins ["@tailwindcss/typography", "tailwindcss-animate"]
+  @tailwind_colors "./tailwind.colors.json"
+
+  def patch(tailwind_config_path) do
+    new_content =
+      tailwind_config_path
+      |> File.read!()
+      |> update_content()
+
+    File.write!(tailwind_config_path, new_content)
+  end
+
+  defp update_content(content) do
+    content
+    |> add_plugins()
+    |> add_theme()
+  end
+
+  defp add_plugins(content) do
+    new_plugins = get_new_plugins(content)
+
+    if Enum.empty?(new_plugins) do
+      content
+    else
+      insert_plugins(content, new_plugins)
+    end
+  end
+
+  defp get_new_plugins(content) do
+    @plugins
+    |> Enum.reject(&String.contains?(content, &1))
+    |> Enum.map(&format_plugin/1)
+  end
+
+  defp format_plugin(plugin), do: "    require(\"#{plugin}\")"
+
+  defp insert_plugins(content, new_plugins) do
+    plugins_code = Enum.join(new_plugins, ",\n")
+
+    if has_plugins_section?(content) do
+      Regex.replace(~r/plugins:\s*\[/, content, "plugins: [\n#{plugins_code},")
+    else
+      Regex.replace(
+        ~r/module\.exports\s*=\s*{/,
+        content,
+        "module.exports = {\n  plugins: [\n#{plugins_code}\n  ],"
+      )
+    end
+  end
+
+  defp has_plugins_section?(content), do: Regex.match?(~r/plugins:\s*\[/, content)
+
+  defp add_theme(content) do
+    # Matches a full theme config in the Tailwind config file
+    # eg. theme: { extend: { colors: require("./tailwind.colors.json") } }
+    theme_regex =
+      ~r/theme:\s*{\s*extend:\s*{\s*colors:\s*require\(['""]#{Regex.escape(@tailwind_colors)}['"]\s*\)\s*}\s*}/
+
+    if Regex.match?(theme_regex, content) do
+      content
+    else
+      content
+      |> ensure_theme_object()
+      |> ensure_extend_object()
+      |> add_colors_config()
+    end
+  end
+
+  defp ensure_theme_object(content) do
+    if has_theme_object?(content) do
+      content
+    else
+      Regex.replace(~r/module\.exports\s*=\s*{/, content, "module.exports = {\n  theme: {},")
+    end
+  end
+
+  defp has_theme_object?(content), do: Regex.match?(~r/theme:\s*{/, content)
+
+  defp ensure_extend_object(content) do
+    if has_extend_object?(content) do
+      content
+    else
+      Regex.replace(~r/(theme:\s*{)/, content, "\\1\n    extend: {},")
+    end
+  end
+
+  defp has_extend_object?(content), do: Regex.match?(~r/theme:\s*{[^}]*extend:\s*{/, content)
+
+  defp add_colors_config(content) do
+    if has_colors_config?(content) do
+      replace_colors_config(content)
+    else
+      insert_colors_config(content)
+    end
+  end
+
+  defp has_colors_config?(content), do: Regex.match?(~r/extend:\s*{[^}]*colors:/, content)
+
+  defp replace_colors_config(content) do
+    # Matches a full colors config in the Tailwind config file
+    # eg. extend: { colors: { brand: "some-color" } }
+    regex = ~r/(extend:\s*{[^}]*)(colors:\s*(?:{[^}]*}|[^,}]+))/
+
+    Regex.replace(
+      regex,
+      content,
+      "\\1colors: require(\"#{@tailwind_colors}\")"
+    )
+  end
+
+  defp insert_colors_config(content) do
+    Regex.replace(
+      ~r/(extend:\s*{)/,
+      content,
+      "\\1\n      colors: require(\"#{@tailwind_colors}\"),"
+    )
+  end
+end

--- a/lib/salad_ui/tasks_helpers.ex
+++ b/lib/salad_ui/tasks_helpers.ex
@@ -1,0 +1,43 @@
+defmodule SaladUi.TasksHelpers do
+  @moduledoc """
+  Helper functions for the SaladUI mix tasks.
+  """
+
+  @doc """
+  Retrieves the base path for SaladUI library source files.
+
+  Returns the appropriate path based on the current environment:
+  - In test: Uses the local `lib/salad_ui` directory.
+  - In development: Locates the path within project dependencies.
+
+  Raises an error if SaladUI cannot be found in the dependencies.
+  """
+  def get_base_path do
+    if Mix.env() == :test, do: test_path(), else: development_path()
+  end
+
+  defp test_path, do: Path.expand("lib/salad_ui")
+
+  defp development_path do
+    case find_salad_ui_dep() do
+      {:ok, path} -> Path.expand(Path.join(path, "lib/salad_ui"))
+      {:error, reason} -> raise "Failed to find SaladUI: #{reason}"
+    end
+  end
+
+  defp find_salad_ui_dep do
+    Mix.Dep.load_and_cache()
+    |> Enum.find(&(&1.app == :salad_ui))
+    |> case do
+      %Mix.Dep{opts: opts} = dep ->
+        {:ok, opts[:path] || default_dep_path(dep)}
+
+      nil ->
+        {:error, "SaladUI not found in dependencies"}
+    end
+  end
+
+  defp default_dep_path(dep) do
+    Path.join([File.cwd!(), "deps", Atom.to_string(dep.app)])
+  end
+end

--- a/priv/static/assets/colors/blue.css
+++ b/priv/static/assets/colors/blue.css
@@ -1,0 +1,54 @@
+:root {
+  --background: 0 0% 100%;
+  --foreground: 222.2 84% 4.9%;
+  --card: 0 0% 100%;
+  --card-foreground: 222.2 84% 4.9%;
+  --popover: 0 0% 100%;
+  --popover-foreground: 222.2 84% 4.9%;
+  --primary: 221.2 83.2% 53.3%;
+  --primary-foreground: 210 40% 98%;
+  --secondary: 210 40% 96.1%;
+  --secondary-foreground: 222.2 47.4% 11.2%;
+  --muted: 210 40% 96.1%;
+  --muted-foreground: 215.4 16.3% 46.9%;
+  --accent: 210 40% 96.1%;
+  --accent-foreground: 222.2 47.4% 11.2%;
+  --destructive: 0 84.2% 60.2%;
+  --destructive-foreground: 210 40% 98%;
+  --border: 214.3 31.8% 91.4%;
+  --input: 214.3 31.8% 91.4%;
+  --ring: 221.2 83.2% 53.3%;
+  --radius: 1rem;
+  --chart-1: 12 76% 61%;
+  --chart-2: 173 58% 39%;
+  --chart-3: 197 37% 24%;
+  --chart-4: 43 74% 66%;
+  --chart-5: 27 87% 67%;
+}
+
+.dark {
+  --background: 222.2 84% 4.9%;
+  --foreground: 210 40% 98%;
+  --card: 222.2 84% 4.9%;
+  --card-foreground: 210 40% 98%;
+  --popover: 222.2 84% 4.9%;
+  --popover-foreground: 210 40% 98%;
+  --primary: 217.2 91.2% 59.8%;
+  --primary-foreground: 222.2 47.4% 11.2%;
+  --secondary: 217.2 32.6% 17.5%;
+  --secondary-foreground: 210 40% 98%;
+  --muted: 217.2 32.6% 17.5%;
+  --muted-foreground: 215 20.2% 65.1%;
+  --accent: 217.2 32.6% 17.5%;
+  --accent-foreground: 210 40% 98%;
+  --destructive: 0 62.8% 30.6%;
+  --destructive-foreground: 210 40% 98%;
+  --border: 217.2 32.6% 17.5%;
+  --input: 217.2 32.6% 17.5%;
+  --ring: 224.3 76.3% 48%;
+  --chart-1: 220 70% 50%;
+  --chart-2: 160 60% 45%;
+  --chart-3: 30 80% 55%;
+  --chart-4: 280 65% 60%;
+  --chart-5: 340 75% 55%;
+}

--- a/priv/static/assets/colors/gray.css
+++ b/priv/static/assets/colors/gray.css
@@ -1,0 +1,54 @@
+:root {
+  --background: 0 0% 100%;
+  --foreground: 224 71.4% 4.1%;
+  --card: 0 0% 100%;
+  --card-foreground: 224 71.4% 4.1%;
+  --popover: 0 0% 100%;
+  --popover-foreground: 224 71.4% 4.1%;
+  --primary: 220.9 39.3% 11%;
+  --primary-foreground: 210 20% 98%;
+  --secondary: 220 14.3% 95.9%;
+  --secondary-foreground: 220.9 39.3% 11%;
+  --muted: 220 14.3% 95.9%;
+  --muted-foreground: 220 8.9% 46.1%;
+  --accent: 220 14.3% 95.9%;
+  --accent-foreground: 220.9 39.3% 11%;
+  --destructive: 0 84.2% 60.2%;
+  --destructive-foreground: 210 20% 98%;
+  --border: 220 13% 91%;
+  --input: 220 13% 91%;
+  --ring: 224 71.4% 4.1%;
+  --radius: 1rem;
+  --chart-1: 12 76% 61%;
+  --chart-2: 173 58% 39%;
+  --chart-3: 197 37% 24%;
+  --chart-4: 43 74% 66%;
+  --chart-5: 27 87% 67%;
+}
+
+.dark {
+  --background: 224 71.4% 4.1%;
+  --foreground: 210 20% 98%;
+  --card: 224 71.4% 4.1%;
+  --card-foreground: 210 20% 98%;
+  --popover: 224 71.4% 4.1%;
+  --popover-foreground: 210 20% 98%;
+  --primary: 210 20% 98%;
+  --primary-foreground: 220.9 39.3% 11%;
+  --secondary: 215 27.9% 16.9%;
+  --secondary-foreground: 210 20% 98%;
+  --muted: 215 27.9% 16.9%;
+  --muted-foreground: 217.9 10.6% 64.9%;
+  --accent: 215 27.9% 16.9%;
+  --accent-foreground: 210 20% 98%;
+  --destructive: 0 62.8% 30.6%;
+  --destructive-foreground: 210 20% 98%;
+  --border: 215 27.9% 16.9%;
+  --input: 215 27.9% 16.9%;
+  --ring: 216 12.2% 83.9%;
+  --chart-1: 220 70% 50%;
+  --chart-2: 160 60% 45%;
+  --chart-3: 30 80% 55%;
+  --chart-4: 280 65% 60%;
+  --chart-5: 340 75% 55%;
+}

--- a/priv/static/assets/colors/green.css
+++ b/priv/static/assets/colors/green.css
@@ -1,0 +1,54 @@
+:root {
+  --background: 0 0% 100%;
+  --foreground: 240 10% 3.9%;
+  --card: 0 0% 100%;
+  --card-foreground: 240 10% 3.9%;
+  --popover: 0 0% 100%;
+  --popover-foreground: 240 10% 3.9%;
+  --primary: 142.1 76.2% 36.3%;
+  --primary-foreground: 355.7 100% 97.3%;
+  --secondary: 240 4.8% 95.9%;
+  --secondary-foreground: 240 5.9% 10%;
+  --muted: 240 4.8% 95.9%;
+  --muted-foreground: 240 3.8% 46.1%;
+  --accent: 240 4.8% 95.9%;
+  --accent-foreground: 240 5.9% 10%;
+  --destructive: 0 84.2% 60.2%;
+  --destructive-foreground: 0 0% 98%;
+  --border: 240 5.9% 90%;
+  --input: 240 5.9% 90%;
+  --ring: 142.1 76.2% 36.3%;
+  --radius: 1rem;
+  --chart-1: 12 76% 61%;
+  --chart-2: 173 58% 39%;
+  --chart-3: 197 37% 24%;
+  --chart-4: 43 74% 66%;
+  --chart-5: 27 87% 67%;
+}
+
+.dark {
+  --background: 20 14.3% 4.1%;
+  --foreground: 0 0% 95%;
+  --card: 24 9.8% 10%;
+  --card-foreground: 0 0% 95%;
+  --popover: 0 0% 9%;
+  --popover-foreground: 0 0% 95%;
+  --primary: 142.1 70.6% 45.3%;
+  --primary-foreground: 144.9 80.4% 10%;
+  --secondary: 240 3.7% 15.9%;
+  --secondary-foreground: 0 0% 98%;
+  --muted: 0 0% 15%;
+  --muted-foreground: 240 5% 64.9%;
+  --accent: 12 6.5% 15.1%;
+  --accent-foreground: 0 0% 98%;
+  --destructive: 0 62.8% 30.6%;
+  --destructive-foreground: 0 85.7% 97.3%;
+  --border: 240 3.7% 15.9%;
+  --input: 240 3.7% 15.9%;
+  --ring: 142.4 71.8% 29.2%;
+  --chart-1: 220 70% 50%;
+  --chart-2: 160 60% 45%;
+  --chart-3: 30 80% 55%;
+  --chart-4: 280 65% 60%;
+  --chart-5: 340 75% 55%;
+}

--- a/priv/static/assets/colors/neutral.css
+++ b/priv/static/assets/colors/neutral.css
@@ -1,0 +1,54 @@
+:root {
+  --background: 0 0% 100%;
+  --foreground: 0 0% 3.9%;
+  --card: 0 0% 100%;
+  --card-foreground: 0 0% 3.9%;
+  --popover: 0 0% 100%;
+  --popover-foreground: 0 0% 3.9%;
+  --primary: 0 0% 9%;
+  --primary-foreground: 0 0% 98%;
+  --secondary: 0 0% 96.1%;
+  --secondary-foreground: 0 0% 9%;
+  --muted: 0 0% 96.1%;
+  --muted-foreground: 0 0% 45.1%;
+  --accent: 0 0% 96.1%;
+  --accent-foreground: 0 0% 9%;
+  --destructive: 0 84.2% 60.2%;
+  --destructive-foreground: 0 0% 98%;
+  --border: 0 0% 89.8%;
+  --input: 0 0% 89.8%;
+  --ring: 0 0% 3.9%;
+  --radius: 1rem;
+  --chart-1: 12 76% 61%;
+  --chart-2: 173 58% 39%;
+  --chart-3: 197 37% 24%;
+  --chart-4: 43 74% 66%;
+  --chart-5: 27 87% 67%;
+}
+
+.dark {
+  --background: 0 0% 3.9%;
+  --foreground: 0 0% 98%;
+  --card: 0 0% 3.9%;
+  --card-foreground: 0 0% 98%;
+  --popover: 0 0% 3.9%;
+  --popover-foreground: 0 0% 98%;
+  --primary: 0 0% 98%;
+  --primary-foreground: 0 0% 9%;
+  --secondary: 0 0% 14.9%;
+  --secondary-foreground: 0 0% 98%;
+  --muted: 0 0% 14.9%;
+  --muted-foreground: 0 0% 63.9%;
+  --accent: 0 0% 14.9%;
+  --accent-foreground: 0 0% 98%;
+  --destructive: 0 62.8% 30.6%;
+  --destructive-foreground: 0 0% 98%;
+  --border: 0 0% 14.9%;
+  --input: 0 0% 14.9%;
+  --ring: 0 0% 83.1%;
+  --chart-1: 220 70% 50%;
+  --chart-2: 160 60% 45%;
+  --chart-3: 30 80% 55%;
+  --chart-4: 280 65% 60%;
+  --chart-5: 340 75% 55%;
+}

--- a/priv/static/assets/colors/orange.css
+++ b/priv/static/assets/colors/orange.css
@@ -1,0 +1,54 @@
+:root {
+  --background: 0 0% 100%;
+  --foreground: 20 14.3% 4.1%;
+  --card: 0 0% 100%;
+  --card-foreground: 20 14.3% 4.1%;
+  --popover: 0 0% 100%;
+  --popover-foreground: 20 14.3% 4.1%;
+  --primary: 24.6 95% 53.1%;
+  --primary-foreground: 60 9.1% 97.8%;
+  --secondary: 60 4.8% 95.9%;
+  --secondary-foreground: 24 9.8% 10%;
+  --muted: 60 4.8% 95.9%;
+  --muted-foreground: 25 5.3% 44.7%;
+  --accent: 60 4.8% 95.9%;
+  --accent-foreground: 24 9.8% 10%;
+  --destructive: 0 84.2% 60.2%;
+  --destructive-foreground: 60 9.1% 97.8%;
+  --border: 20 5.9% 90%;
+  --input: 20 5.9% 90%;
+  --ring: 24.6 95% 53.1%;
+  --radius: 1rem;
+  --chart-1: 12 76% 61%;
+  --chart-2: 173 58% 39%;
+  --chart-3: 197 37% 24%;
+  --chart-4: 43 74% 66%;
+  --chart-5: 27 87% 67%;
+}
+
+.dark {
+  --background: 20 14.3% 4.1%;
+  --foreground: 60 9.1% 97.8%;
+  --card: 20 14.3% 4.1%;
+  --card-foreground: 60 9.1% 97.8%;
+  --popover: 20 14.3% 4.1%;
+  --popover-foreground: 60 9.1% 97.8%;
+  --primary: 20.5 90.2% 48.2%;
+  --primary-foreground: 60 9.1% 97.8%;
+  --secondary: 12 6.5% 15.1%;
+  --secondary-foreground: 60 9.1% 97.8%;
+  --muted: 12 6.5% 15.1%;
+  --muted-foreground: 24 5.4% 63.9%;
+  --accent: 12 6.5% 15.1%;
+  --accent-foreground: 60 9.1% 97.8%;
+  --destructive: 0 72.2% 50.6%;
+  --destructive-foreground: 60 9.1% 97.8%;
+  --border: 12 6.5% 15.1%;
+  --input: 12 6.5% 15.1%;
+  --ring: 20.5 90.2% 48.2%;
+  --chart-1: 220 70% 50%;
+  --chart-2: 160 60% 45%;
+  --chart-3: 30 80% 55%;
+  --chart-4: 280 65% 60%;
+  --chart-5: 340 75% 55%;
+}

--- a/priv/static/assets/colors/red.css
+++ b/priv/static/assets/colors/red.css
@@ -1,0 +1,54 @@
+:root {
+  --background: 0 0% 100%;
+  --foreground: 0 0% 3.9%;
+  --card: 0 0% 100%;
+  --card-foreground: 0 0% 3.9%;
+  --popover: 0 0% 100%;
+  --popover-foreground: 0 0% 3.9%;
+  --primary: 0 72.2% 50.6%;
+  --primary-foreground: 0 85.7% 97.3%;
+  --secondary: 0 0% 96.1%;
+  --secondary-foreground: 0 0% 9%;
+  --muted: 0 0% 96.1%;
+  --muted-foreground: 0 0% 45.1%;
+  --accent: 0 0% 96.1%;
+  --accent-foreground: 0 0% 9%;
+  --destructive: 0 84.2% 60.2%;
+  --destructive-foreground: 0 0% 98%;
+  --border: 0 0% 89.8%;
+  --input: 0 0% 89.8%;
+  --ring: 0 72.2% 50.6%;
+  --radius: 1rem;
+  --chart-1: 12 76% 61%;
+  --chart-2: 173 58% 39%;
+  --chart-3: 197 37% 24%;
+  --chart-4: 43 74% 66%;
+  --chart-5: 27 87% 67%;
+}
+
+.dark {
+  --background: 0 0% 3.9%;
+  --foreground: 0 0% 98%;
+  --card: 0 0% 3.9%;
+  --card-foreground: 0 0% 98%;
+  --popover: 0 0% 3.9%;
+  --popover-foreground: 0 0% 98%;
+  --primary: 0 72.2% 50.6%;
+  --primary-foreground: 0 85.7% 97.3%;
+  --secondary: 0 0% 14.9%;
+  --secondary-foreground: 0 0% 98%;
+  --muted: 0 0% 14.9%;
+  --muted-foreground: 0 0% 63.9%;
+  --accent: 0 0% 14.9%;
+  --accent-foreground: 0 0% 98%;
+  --destructive: 0 62.8% 30.6%;
+  --destructive-foreground: 0 0% 98%;
+  --border: 0 0% 14.9%;
+  --input: 0 0% 14.9%;
+  --ring: 0 72.2% 50.6%;
+  --chart-1: 220 70% 50%;
+  --chart-2: 160 60% 45%;
+  --chart-3: 30 80% 55%;
+  --chart-4: 280 65% 60%;
+  --chart-5: 340 75% 55%;
+}

--- a/priv/static/assets/colors/rose.css
+++ b/priv/static/assets/colors/rose.css
@@ -1,0 +1,54 @@
+:root {
+  --background: 0 0% 100%;
+  --foreground: 240 10% 3.9%;
+  --card: 0 0% 100%;
+  --card-foreground: 240 10% 3.9%;
+  --popover: 0 0% 100%;
+  --popover-foreground: 240 10% 3.9%;
+  --primary: 346.8 77.2% 49.8%;
+  --primary-foreground: 355.7 100% 97.3%;
+  --secondary: 240 4.8% 95.9%;
+  --secondary-foreground: 240 5.9% 10%;
+  --muted: 240 4.8% 95.9%;
+  --muted-foreground: 240 3.8% 46.1%;
+  --accent: 240 4.8% 95.9%;
+  --accent-foreground: 240 5.9% 10%;
+  --destructive: 0 84.2% 60.2%;
+  --destructive-foreground: 0 0% 98%;
+  --border: 240 5.9% 90%;
+  --input: 240 5.9% 90%;
+  --ring: 346.8 77.2% 49.8%;
+  --radius: 1rem;
+  --chart-1: 12 76% 61%;
+  --chart-2: 173 58% 39%;
+  --chart-3: 197 37% 24%;
+  --chart-4: 43 74% 66%;
+  --chart-5: 27 87% 67%;
+}
+
+.dark {
+  --background: 20 14.3% 4.1%;
+  --foreground: 0 0% 95%;
+  --card: 24 9.8% 10%;
+  --card-foreground: 0 0% 95%;
+  --popover: 0 0% 9%;
+  --popover-foreground: 0 0% 95%;
+  --primary: 346.8 77.2% 49.8%;
+  --primary-foreground: 355.7 100% 97.3%;
+  --secondary: 240 3.7% 15.9%;
+  --secondary-foreground: 0 0% 98%;
+  --muted: 0 0% 15%;
+  --muted-foreground: 240 5% 64.9%;
+  --accent: 12 6.5% 15.1%;
+  --accent-foreground: 0 0% 98%;
+  --destructive: 0 62.8% 30.6%;
+  --destructive-foreground: 0 85.7% 97.3%;
+  --border: 240 3.7% 15.9%;
+  --input: 240 3.7% 15.9%;
+  --ring: 346.8 77.2% 49.8%;
+  --chart-1: 220 70% 50%;
+  --chart-2: 160 60% 45%;
+  --chart-3: 30 80% 55%;
+  --chart-4: 280 65% 60%;
+  --chart-5: 340 75% 55%;
+}

--- a/priv/static/assets/colors/slate.css
+++ b/priv/static/assets/colors/slate.css
@@ -1,0 +1,54 @@
+:root {
+  --background: 0 0% 100%;
+  --foreground: 222.2 84% 4.9%;
+  --card: 0 0% 100%;
+  --card-foreground: 222.2 84% 4.9%;
+  --popover: 0 0% 100%;
+  --popover-foreground: 222.2 84% 4.9%;
+  --primary: 222.2 47.4% 11.2%;
+  --primary-foreground: 210 40% 98%;
+  --secondary: 210 40% 96.1%;
+  --secondary-foreground: 222.2 47.4% 11.2%;
+  --muted: 210 40% 96.1%;
+  --muted-foreground: 215.4 16.3% 46.9%;
+  --accent: 210 40% 96.1%;
+  --accent-foreground: 222.2 47.4% 11.2%;
+  --destructive: 0 84.2% 60.2%;
+  --destructive-foreground: 210 40% 98%;
+  --border: 214.3 31.8% 91.4%;
+  --input: 214.3 31.8% 91.4%;
+  --ring: 222.2 84% 4.9%;
+  --radius: 1rem;
+  --chart-1: 12 76% 61%;
+  --chart-2: 173 58% 39%;
+  --chart-3: 197 37% 24%;
+  --chart-4: 43 74% 66%;
+  --chart-5: 27 87% 67%;
+}
+
+.dark {
+  --background: 222.2 84% 4.9%;
+  --foreground: 210 40% 98%;
+  --card: 222.2 84% 4.9%;
+  --card-foreground: 210 40% 98%;
+  --popover: 222.2 84% 4.9%;
+  --popover-foreground: 210 40% 98%;
+  --primary: 210 40% 98%;
+  --primary-foreground: 222.2 47.4% 11.2%;
+  --secondary: 217.2 32.6% 17.5%;
+  --secondary-foreground: 210 40% 98%;
+  --muted: 217.2 32.6% 17.5%;
+  --muted-foreground: 215 20.2% 65.1%;
+  --accent: 217.2 32.6% 17.5%;
+  --accent-foreground: 210 40% 98%;
+  --destructive: 0 62.8% 30.6%;
+  --destructive-foreground: 210 40% 98%;
+  --border: 217.2 32.6% 17.5%;
+  --input: 217.2 32.6% 17.5%;
+  --ring: 212.7 26.8% 83.9;
+  --chart-1: 220 70% 50%;
+  --chart-2: 160 60% 45%;
+  --chart-3: 30 80% 55%;
+  --chart-4: 280 65% 60%;
+  --chart-5: 340 75% 55%;
+}

--- a/priv/static/assets/colors/stone.css
+++ b/priv/static/assets/colors/stone.css
@@ -1,0 +1,54 @@
+:root {
+  --background: 0 0% 100%;
+  --foreground: 20 14.3% 4.1%;
+  --card: 0 0% 100%;
+  --card-foreground: 20 14.3% 4.1%;
+  --popover: 0 0% 100%;
+  --popover-foreground: 20 14.3% 4.1%;
+  --primary: 24 9.8% 10%;
+  --primary-foreground: 60 9.1% 97.8%;
+  --secondary: 60 4.8% 95.9%;
+  --secondary-foreground: 24 9.8% 10%;
+  --muted: 60 4.8% 95.9%;
+  --muted-foreground: 25 5.3% 44.7%;
+  --accent: 60 4.8% 95.9%;
+  --accent-foreground: 24 9.8% 10%;
+  --destructive: 0 84.2% 60.2%;
+  --destructive-foreground: 60 9.1% 97.8%;
+  --border: 20 5.9% 90%;
+  --input: 20 5.9% 90%;
+  --ring: 20 14.3% 4.1%;
+  --radius: 1rem;
+  --chart-1: 12 76% 61%;
+  --chart-2: 173 58% 39%;
+  --chart-3: 197 37% 24%;
+  --chart-4: 43 74% 66%;
+  --chart-5: 27 87% 67%;
+}
+
+.dark {
+  --background: 20 14.3% 4.1%;
+  --foreground: 60 9.1% 97.8%;
+  --card: 20 14.3% 4.1%;
+  --card-foreground: 60 9.1% 97.8%;
+  --popover: 20 14.3% 4.1%;
+  --popover-foreground: 60 9.1% 97.8%;
+  --primary: 60 9.1% 97.8%;
+  --primary-foreground: 24 9.8% 10%;
+  --secondary: 12 6.5% 15.1%;
+  --secondary-foreground: 60 9.1% 97.8%;
+  --muted: 12 6.5% 15.1%;
+  --muted-foreground: 24 5.4% 63.9%;
+  --accent: 12 6.5% 15.1%;
+  --accent-foreground: 60 9.1% 97.8%;
+  --destructive: 0 62.8% 30.6%;
+  --destructive-foreground: 60 9.1% 97.8%;
+  --border: 12 6.5% 15.1%;
+  --input: 12 6.5% 15.1%;
+  --ring: 24 5.7% 82.9%;
+  --chart-1: 220 70% 50%;
+  --chart-2: 160 60% 45%;
+  --chart-3: 30 80% 55%;
+  --chart-4: 280 65% 60%;
+  --chart-5: 340 75% 55%;
+}

--- a/priv/static/assets/colors/violet.css
+++ b/priv/static/assets/colors/violet.css
@@ -1,0 +1,54 @@
+:root {
+  --background: 0 0% 100%;
+  --foreground: 224 71.4% 4.1%;
+  --card: 0 0% 100%;
+  --card-foreground: 224 71.4% 4.1%;
+  --popover: 0 0% 100%;
+  --popover-foreground: 224 71.4% 4.1%;
+  --primary: 262.1 83.3% 57.8%;
+  --primary-foreground: 210 20% 98%;
+  --secondary: 220 14.3% 95.9%;
+  --secondary-foreground: 220.9 39.3% 11%;
+  --muted: 220 14.3% 95.9%;
+  --muted-foreground: 220 8.9% 46.1%;
+  --accent: 220 14.3% 95.9%;
+  --accent-foreground: 220.9 39.3% 11%;
+  --destructive: 0 84.2% 60.2%;
+  --destructive-foreground: 210 20% 98%;
+  --border: 220 13% 91%;
+  --input: 220 13% 91%;
+  --ring: 262.1 83.3% 57.8%;
+  --radius: 1rem;
+  --chart-1: 12 76% 61%;
+  --chart-2: 173 58% 39%;
+  --chart-3: 197 37% 24%;
+  --chart-4: 43 74% 66%;
+  --chart-5: 27 87% 67%;
+}
+
+.dark {
+  --background: 224 71.4% 4.1%;
+  --foreground: 210 20% 98%;
+  --card: 224 71.4% 4.1%;
+  --card-foreground: 210 20% 98%;
+  --popover: 224 71.4% 4.1%;
+  --popover-foreground: 210 20% 98%;
+  --primary: 263.4 70% 50.4%;
+  --primary-foreground: 210 20% 98%;
+  --secondary: 215 27.9% 16.9%;
+  --secondary-foreground: 210 20% 98%;
+  --muted: 215 27.9% 16.9%;
+  --muted-foreground: 217.9 10.6% 64.9%;
+  --accent: 215 27.9% 16.9%;
+  --accent-foreground: 210 20% 98%;
+  --destructive: 0 62.8% 30.6%;
+  --destructive-foreground: 210 20% 98%;
+  --border: 215 27.9% 16.9%;
+  --input: 215 27.9% 16.9%;
+  --ring: 263.4 70% 50.4%;
+  --chart-1: 220 70% 50%;
+  --chart-2: 160 60% 45%;
+  --chart-3: 30 80% 55%;
+  --chart-4: 280 65% 60%;
+  --chart-5: 340 75% 55%;
+}

--- a/priv/static/assets/colors/yellow.css
+++ b/priv/static/assets/colors/yellow.css
@@ -1,0 +1,54 @@
+:root {
+  --background: 0 0% 100%;
+  --foreground: 20 14.3% 4.1%;
+  --card: 0 0% 100%;
+  --card-foreground: 20 14.3% 4.1%;
+  --popover: 0 0% 100%;
+  --popover-foreground: 20 14.3% 4.1%;
+  --primary: 47.9 95.8% 53.1%;
+  --primary-foreground: 26 83.3% 14.1%;
+  --secondary: 60 4.8% 95.9%;
+  --secondary-foreground: 24 9.8% 10%;
+  --muted: 60 4.8% 95.9%;
+  --muted-foreground: 25 5.3% 44.7%;
+  --accent: 60 4.8% 95.9%;
+  --accent-foreground: 24 9.8% 10%;
+  --destructive: 0 84.2% 60.2%;
+  --destructive-foreground: 60 9.1% 97.8%;
+  --border: 20 5.9% 90%;
+  --input: 20 5.9% 90%;
+  --ring: 20 14.3% 4.1%;
+  --radius: 1rem;
+  --chart-1: 12 76% 61%;
+  --chart-2: 173 58% 39%;
+  --chart-3: 197 37% 24%;
+  --chart-4: 43 74% 66%;
+  --chart-5: 27 87% 67%;
+}
+
+.dark {
+  --background: 20 14.3% 4.1%;
+  --foreground: 60 9.1% 97.8%;
+  --card: 20 14.3% 4.1%;
+  --card-foreground: 60 9.1% 97.8%;
+  --popover: 20 14.3% 4.1%;
+  --popover-foreground: 60 9.1% 97.8%;
+  --primary: 47.9 95.8% 53.1%;
+  --primary-foreground: 26 83.3% 14.1%;
+  --secondary: 12 6.5% 15.1%;
+  --secondary-foreground: 60 9.1% 97.8%;
+  --muted: 12 6.5% 15.1%;
+  --muted-foreground: 24 5.4% 63.9%;
+  --accent: 12 6.5% 15.1%;
+  --accent-foreground: 60 9.1% 97.8%;
+  --destructive: 0 62.8% 30.6%;
+  --destructive-foreground: 60 9.1% 97.8%;
+  --border: 12 6.5% 15.1%;
+  --input: 12 6.5% 15.1%;
+  --ring: 35.5 91.7% 32.9%;
+  --chart-1: 220 70% 50%;
+  --chart-2: 160 60% 45%;
+  --chart-3: 30 80% 55%;
+  --chart-4: 280 65% 60%;
+  --chart-5: 340 75% 55%;
+}

--- a/priv/static/assets/colors/zinc.css
+++ b/priv/static/assets/colors/zinc.css
@@ -1,0 +1,44 @@
+:root {
+  --background: 0 0% 100%;
+  --foreground: 240 10% 3.9%;
+  --card: 0 0% 100%;
+  --card-foreground: 240 10% 3.9%;
+  --popover: 0 0% 100%;
+  --popover-foreground: 240 10% 3.9%;
+  --primary: 240 5.9% 10%;
+  --primary-foreground: 0 0% 98%;
+  --secondary: 240 4.8% 95.9%;
+  --secondary-foreground: 240 5.9% 10%;
+  --muted: 240 4.8% 95.9%;
+  --muted-foreground: 240 3.8% 46.1%;
+  --accent: 240 4.8% 95.9%;
+  --accent-foreground: 240 5.9% 10%;
+  --destructive: 0 84.2% 60.2%;
+  --destructive-foreground: 0 0% 98%;
+  --border: 240 5.9% 90%;
+  --input: 240 5.9% 90%;
+  --ring: 240 5.9% 10%;
+  --radius: 0.3rem;
+}
+
+.dark {
+  --background: 240 10% 3.9%;
+  --foreground: 0 0% 98%;
+  --card: 240 10% 3.9%;
+  --card-foreground: 0 0% 98%;
+  --popover: 240 10% 3.9%;
+  --popover-foreground: 0 0% 98%;
+  --primary: 0 0% 98%;
+  --primary-foreground: 240 5.9% 10%;
+  --secondary: 240 3.7% 15.9%;
+  --secondary-foreground: 0 0% 98%;
+  --muted: 240 3.7% 15.9%;
+  --muted-foreground: 240 5% 64.9%;
+  --accent: 240 3.7% 15.9%;
+  --accent-foreground: 0 0% 98%;
+  --destructive: 0 62.8% 30.6%;
+  --destructive-foreground: 0 0% 98%;
+  --border: 240 3.7% 15.9%;
+  --input: 240 3.7% 15.9%;
+  --ring: 240 4.9% 83.9%;
+}

--- a/priv/static/assets/server-events.js
+++ b/priv/static/assets/server-events.js
@@ -1,0 +1,5 @@
+window.addEventListener("phx:js-exec", ({detail}) => {
+  document.querySelectorAll(detail.to).forEach(el => {
+    liveSocket.execJS(el, el.getAttribute(detail.attr))
+  })
+})

--- a/priv/static/assets/tailwind.colors.json
+++ b/priv/static/assets/tailwind.colors.json
@@ -1,0 +1,35 @@
+{
+  "accent": {
+    "DEFAULT": "hsl(var(--accent))",
+    "foreground": "hsl(var(--accent-foreground))"
+  },
+  "background": "hsl(var(--background))",
+  "border": "hsl(var(--border))",
+  "card": {
+    "DEFAULT": "hsl(var(--card))",
+    "foreground": "hsl(var(--card-foreground))"
+  },
+  "destructive": {
+    "DEFAULT": "hsl(var(--destructive))",
+    "foreground": "hsl(var(--destructive-foreground))"
+  },
+  "foreground": "hsl(var(--foreground))",
+  "input": "hsl(var(--input))",
+  "muted": {
+    "DEFAULT": "hsl(var(--muted))",
+    "foreground": "hsl(var(--muted-foreground))"
+  },
+  "popover": {
+    "DEFAULT": "hsl(var(--popover))",
+    "foreground": "hsl(var(--popover-foreground))"
+  },
+  "primary": {
+    "DEFAULT": "hsl(var(--primary))",
+    "foreground": "hsl(var(--primary-foreground))"
+  },
+  "ring": "hsl(var(--ring))",
+  "secondary": {
+    "DEFAULT": "hsl(var(--secondary))",
+    "foreground": "hsl(var(--secondary-foreground))"
+  }
+}

--- a/priv/templates/component.eex
+++ b/priv/templates/component.eex
@@ -1,0 +1,24 @@
+defmodule <%= @module_name %>Web.Component do
+  @moduledoc """
+  The entrypoint for defining UI components.
+
+  This can be used in your components as:
+
+    use <%= @module_name %>Web
+
+  Do NOT define functions inside the quoted expressions
+  below. Instead, define additional modules and import
+  those modules here.
+  """
+
+  defmacro __using__(_) do
+    quote do
+      use Phoenix.Component
+
+      import <%= @module_name %>Web.Helpers
+      import Tails, only: [classes: 1]
+
+      alias Phoenix.LiveView.JS
+    end
+  end
+end

--- a/test/mix/salad.add_test.exs
+++ b/test/mix/salad.add_test.exs
@@ -1,0 +1,50 @@
+defmodule Mix.Tasks.Salad.AddTest do
+  use SaladUI.Test.MixTaskCase
+
+  alias Mix.Tasks.Salad.Add
+
+  # The salad.add mix task returns a shortened list of available components
+  # when we are in test environment. This module attribute should match that
+  # list to ensure the task behaves as expected. See
+  # `list_available_components/1` of `Mix.Tasks.Salad.Add` module
+  @available_components ["button", "card", "input"]
+
+  @components_path "test/support/components"
+
+  setup do
+    Application.put_env(:salad_ui, :components_path, @components_path)
+
+    on_exit(fn ->
+      Application.delete_env(:salad_ui, :components_path)
+      File.rm_rf!(@components_path)
+    end)
+
+    :ok
+  end
+
+  test "run/1 with 'all' installs all available components" do
+    File.mkdir_p!(@components_path)
+    Add.run(["all"])
+
+    Enum.each(@available_components, fn component ->
+      assert_mix_output(:info, "#{component} component installed successfully ✅")
+      assert File.exists?("test/support/components/#{component}.ex")
+    end)
+  end
+
+  test "run/1 with valid component names installs specified components" do
+    Add.run(["button", "card"])
+
+    assert_mix_output(:info, "button component installed successfully ✅")
+    assert_mix_output(:info, "card component installed successfully ✅")
+    assert File.exists?("test/support/components/button.ex")
+    assert File.exists?("test/support/components/card.ex")
+    refute File.exists?("test/support/components/progress.ex")
+  end
+
+  test "run/1 with invalid component names reports errors" do
+    Add.run(["invalid_component"])
+
+    assert_mix_output(:error, "Invalid components:\ninvalid_component")
+  end
+end

--- a/test/mix/salad.init_test.exs
+++ b/test/mix/salad.init_test.exs
@@ -1,0 +1,72 @@
+defmodule Mix.Tasks.Salad.InitTest do
+  use SaladUI.Test.MixTaskCase, async: true
+
+  alias Mix.Tasks.Salad.Init
+
+  @tmp_dir "test_init"
+  @default_components_path Path.join([@tmp_dir, "lib/test_app_web/components/ui"])
+
+  setup do
+    # The shell asks for a path to install components.
+    # We will use the default path for testing.
+    send(self(), {:mix_shell_input, :prompt, @default_components_path})
+
+    # The shell asks for a color scheme to use.
+    # We will use the default color scheme for testing
+    # by entering an empty string.
+    send(self(), {:mix_shell_input, :prompt, ""})
+
+    :ok
+  end
+
+  test "run/1 initializes SaladUI" do
+    in_tmp(@tmp_dir, fn ->
+      # Create a mock mix.exs file
+      File.write!("mix.exs", "defmodule TestApp.MixProject do use Mix.Project\nend")
+
+      File.mkdir_p!("config")
+      File.mkdir_p!("assets/css")
+      File.mkdir_p!("assets/js")
+      File.mkdir_p!(@default_components_path)
+
+      File.write!("config/config.exs", "import Config\n")
+      File.write!("assets/css/app.css", "/* Original app.css content */\n")
+      File.write!("assets/js/app.js", "// Original app.js content\n")
+      File.write!("assets/tailwind.config.js", "module.exports = {\n  // Original tailwind config\n}\n")
+
+      # Mock the _build directory structure
+      priv_dir = "_build/test/lib/salad_ui/priv/static/assets"
+      File.mkdir_p!(priv_dir)
+      File.write!(Path.join(priv_dir, "tailwind.colors.json"), "{}")
+      File.write!(Path.join(priv_dir, "server-events.js"), "// server events")
+      File.mkdir_p!(Path.join(priv_dir, "colors"))
+      File.write!(Path.join([priv_dir, "colors", "gray.css"]), "/* gray theme */")
+
+      Init.run([])
+
+      # Allow some time for file operations to complete
+      :timer.sleep(100)
+
+      assert File.exists?(@default_components_path)
+
+      config_content = File.read!("config/config.exs")
+      assert config_content =~ "import Config"
+      assert config_content =~ "config :salad_ui, components_path:"
+      assert config_content =~ "Path.join(File.cwd!(), \"#{@default_components_path}\")"
+      assert config_content =~ "config :tails, colors_file:"
+      assert config_content =~ "Path.join(File.cwd!(), \"assets/tailwind.colors.json\")"
+
+      assert File.read!("assets/css/app.css") =~ "/* gray theme */"
+      assert File.read!("assets/js/app.js") =~ "// server events"
+      assert File.exists?("assets/tailwind.colors.json")
+      assert File.read!("assets/tailwind.config.js") =~ "require(\"./tailwind.colors.json\")"
+    end)
+  end
+
+  test "run/1 handles errors gracefully" do
+    in_tmp(@tmp_dir, fn ->
+      Init.run([])
+      assert_received {:mix_shell, :error, ["Error during setup: config.exs not found"]}
+    end)
+  end
+end

--- a/test/mix/salad.init_test.exs
+++ b/test/mix/salad.init_test.exs
@@ -30,9 +30,16 @@ defmodule Mix.Tasks.Salad.InitTest do
       File.mkdir_p!(@default_components_path)
 
       File.write!("config/config.exs", "import Config\n")
+      File.write!("config/dev.exs", "import Config\n")
       File.write!("assets/css/app.css", "/* Original app.css content */\n")
       File.write!("assets/js/app.js", "// Original app.js content\n")
       File.write!("assets/tailwind.config.js", "module.exports = {\n  // Original tailwind config\n}\n")
+
+      # Both helpers.ex and component.ex are created
+      # in a path built using the app name.
+      # In test, the app name is "salad_ui", so
+      # we need the path `salad_ui_web` and search those file in that path
+      File.mkdir_p!("lib/salad_ui_web")
 
       # Mock the _build directory structure
       priv_dir = "_build/test/lib/salad_ui/priv/static/assets"
@@ -42,6 +49,10 @@ defmodule Mix.Tasks.Salad.InitTest do
       File.mkdir_p!(Path.join(priv_dir, "colors"))
       File.write!(Path.join([priv_dir, "colors", "gray.css"]), "/* gray theme */")
 
+      # Mock a helper source file
+      File.mkdir_p!("lib/salad_ui")
+      File.write!("lib/salad_ui/helpers.ex", "defmodule TestAppWeb.Helpers do")
+
       Init.run([])
 
       # Allow some time for file operations to complete
@@ -50,23 +61,26 @@ defmodule Mix.Tasks.Salad.InitTest do
       assert File.exists?(@default_components_path)
 
       config_content = File.read!("config/config.exs")
-      assert config_content =~ "import Config"
-      assert config_content =~ "config :salad_ui, components_path:"
-      assert config_content =~ "Path.join(File.cwd!(), \"#{@default_components_path}\")"
       assert config_content =~ "config :tails, colors_file:"
       assert config_content =~ "Path.join(File.cwd!(), \"assets/tailwind.colors.json\")"
+
+      dev_config_content = File.read!("config/dev.exs")
+      assert dev_config_content =~ "config :salad_ui, components_path:"
+      assert dev_config_content =~ "Path.join(File.cwd!(), \"#{@default_components_path}\")"
 
       assert File.read!("assets/css/app.css") =~ "/* gray theme */"
       assert File.read!("assets/js/app.js") =~ "// server events"
       assert File.exists?("assets/tailwind.colors.json")
       assert File.read!("assets/tailwind.config.js") =~ "require(\"./tailwind.colors.json\")"
+      assert File.read!("lib/salad_ui_web/helpers.ex") =~ "defmodule TestAppWeb.Helpers do"
+      assert File.read!("lib/salad_ui_web/component.ex") =~ "defmodule SaladUiWeb.Component do"
     end)
   end
 
   test "run/1 handles errors gracefully" do
     in_tmp(@tmp_dir, fn ->
       Init.run([])
-      assert_received {:mix_shell, :error, ["Error during setup: config.exs not found"]}
+      assert_mix_output(:error, "Error during setup: dev.exs not found")
     end)
   end
 end

--- a/test/salad_ui/patcher/config_patcher_test.exs
+++ b/test/salad_ui/patcher/config_patcher_test.exs
@@ -1,0 +1,88 @@
+defmodule SaladUI.Patcher.ConfigPatcherTest do
+  use ExUnit.Case
+
+  alias SaladUI.Patcher.ConfigPatcher
+
+  @temp_dir "tmp/test"
+  @config_file Path.join(@temp_dir, "config.exs")
+  @components_path "lib/components"
+
+  setup do
+    File.mkdir_p!(@temp_dir)
+    on_exit(fn -> File.rm_rf!(@temp_dir) end)
+  end
+
+  describe "Test config patcher" do
+    test "patch/2 adds salad_ui config when it's missing" do
+      initial_content = """
+      import Config
+      """
+
+      File.write!(@config_file, initial_content)
+
+      ConfigPatcher.patch(@config_file, @components_path)
+
+      assert File.read!(@config_file) =~ "config :salad_ui,"
+      assert File.read!(@config_file) =~ "components_path: Path.join(File.cwd!(), \"#{@components_path}\")"
+    end
+
+    test "patch/2 adds tails config when it's missing" do
+      initial_content = """
+      import Config
+      """
+
+      File.write!(@config_file, initial_content)
+
+      ConfigPatcher.patch(@config_file, @components_path)
+
+      assert File.read!(@config_file) =~ "config :tails,"
+      assert File.read!(@config_file) =~ "colors_file: Path.join(File.cwd!(), \"assets/tailwind.colors.json\")"
+    end
+
+    test "patch/2 adds both salad_ui and tails configs when they're missing" do
+      initial_content = """
+      import Config
+      """
+
+      File.write!(@config_file, initial_content)
+
+      ConfigPatcher.patch(@config_file, @components_path)
+
+      assert File.read!(@config_file) =~ "config :salad_ui,"
+      assert File.read!(@config_file) =~ "components_path: Path.join(File.cwd!(), \"#{@components_path}\")"
+      assert File.read!(@config_file) =~ "config :tails,"
+      assert File.read!(@config_file) =~ "colors_file: Path.join(File.cwd!(), \"assets/tailwind.colors.json\")"
+    end
+
+    test "patch/2 doesn't add configs when they already exist" do
+      initial_content = """
+      import Config
+      config :salad_ui, components_path: "/some/path"
+      config :tails, colors_file: "/some/file.json"
+      """
+
+      File.write!(@config_file, initial_content)
+
+      ConfigPatcher.patch(@config_file, @components_path)
+
+      assert File.read!(@config_file) == initial_content
+    end
+
+    test "patch/2 inserts config before import_config if present" do
+      initial_content = """
+      import Config
+      # Some comment
+      import_config "#{Mix.env()}.exs"
+      """
+
+      File.write!(@config_file, initial_content)
+
+      ConfigPatcher.patch(@config_file, @components_path)
+
+      content = File.read!(@config_file)
+      assert content =~ "config :salad_ui,"
+      assert content =~ "config :tails,"
+      assert String.ends_with?(content, "import_config \"#{Mix.env()}.exs\"\n")
+    end
+  end
+end

--- a/test/salad_ui/patcher/config_patcher_test.exs
+++ b/test/salad_ui/patcher/config_patcher_test.exs
@@ -20,7 +20,14 @@ defmodule SaladUI.Patcher.ConfigPatcherTest do
 
       File.write!(@config_file, initial_content)
 
-      ConfigPatcher.patch(@config_file, @components_path)
+      configs_to_add = [
+        salad_ui: %{
+          description: "Path to install SaladUI components",
+          values: [components_path: "Path.join(File.cwd!(), \"#{@components_path}\")"]
+        }
+      ]
+
+      ConfigPatcher.patch(@config_file, configs: configs_to_add)
 
       assert File.read!(@config_file) =~ "config :salad_ui,"
       assert File.read!(@config_file) =~ "components_path: Path.join(File.cwd!(), \"#{@components_path}\")"
@@ -33,7 +40,14 @@ defmodule SaladUI.Patcher.ConfigPatcherTest do
 
       File.write!(@config_file, initial_content)
 
-      ConfigPatcher.patch(@config_file, @components_path)
+      configs_to_add = [
+        tails: %{
+          description: "SaladUI use tails to properly merge Tailwind CSS classes",
+          values: [colors_file: "Path.join(File.cwd!(), \"assets/tailwind.colors.json\")"]
+        }
+      ]
+
+      ConfigPatcher.patch(@config_file, configs: configs_to_add)
 
       assert File.read!(@config_file) =~ "config :tails,"
       assert File.read!(@config_file) =~ "colors_file: Path.join(File.cwd!(), \"assets/tailwind.colors.json\")"
@@ -46,7 +60,18 @@ defmodule SaladUI.Patcher.ConfigPatcherTest do
 
       File.write!(@config_file, initial_content)
 
-      ConfigPatcher.patch(@config_file, @components_path)
+      configs_to_add = [
+        salad_ui: %{
+          description: "Path to install SaladUI components",
+          values: [components_path: "Path.join(File.cwd!(), \"#{@components_path}\")"]
+        },
+        tails: %{
+          description: "SaladUI use tails to properly merge Tailwind CSS classes",
+          values: [colors_file: "Path.join(File.cwd!(), \"assets/tailwind.colors.json\")"]
+        }
+      ]
+
+      ConfigPatcher.patch(@config_file, configs: configs_to_add)
 
       assert File.read!(@config_file) =~ "config :salad_ui,"
       assert File.read!(@config_file) =~ "components_path: Path.join(File.cwd!(), \"#{@components_path}\")"
@@ -61,9 +86,20 @@ defmodule SaladUI.Patcher.ConfigPatcherTest do
       config :tails, colors_file: "/some/file.json"
       """
 
+      configs_to_add = [
+        salad_ui: %{
+          description: "Path to install SaladUI components",
+          values: [components_path: "Path.join(File.cwd!(), \"#{@components_path}\")"]
+        },
+        tails: %{
+          description: "SaladUI use tails to properly merge Tailwind CSS classes",
+          values: [colors_file: "Path.join(File.cwd!(), \"assets/tailwind.colors.json\")"]
+        }
+      ]
+
       File.write!(@config_file, initial_content)
 
-      ConfigPatcher.patch(@config_file, @components_path)
+      ConfigPatcher.patch(@config_file, configs: configs_to_add)
 
       assert File.read!(@config_file) == initial_content
     end
@@ -77,7 +113,18 @@ defmodule SaladUI.Patcher.ConfigPatcherTest do
 
       File.write!(@config_file, initial_content)
 
-      ConfigPatcher.patch(@config_file, @components_path)
+      configs_to_add = [
+        salad_ui: %{
+          description: "Path to install SaladUI components",
+          values: [components_path: "Path.join(File.cwd!(), \"#{@components_path}\")"]
+        },
+        tails: %{
+          description: "SaladUI use tails to properly merge Tailwind CSS classes",
+          values: [colors_file: "Path.join(File.cwd!(), \"assets/tailwind.colors.json\")"]
+        }
+      ]
+
+      ConfigPatcher.patch(@config_file, configs: configs_to_add)
 
       content = File.read!(@config_file)
       assert content =~ "config :salad_ui,"

--- a/test/salad_ui/patcher/css_patcher_test.exs
+++ b/test/salad_ui/patcher/css_patcher_test.exs
@@ -1,0 +1,89 @@
+defmodule SaladUI.Patcher.CSSPatcherTest do
+  use ExUnit.Case
+
+  alias SaladUI.Patcher.CSSPatcher
+
+  @temp_dir "test/temp"
+  @css_file "#{@temp_dir}/app.css"
+  @color_scheme_file "#{@temp_dir}/color_scheme.css"
+
+  setup do
+    File.mkdir_p!(@temp_dir)
+    on_exit(fn -> File.rm_rf!(@temp_dir) end)
+  end
+
+  describe "Test CSS patcher" do
+    test "patch/2 adds color scheme and body tweaks when CSS file is empty" do
+      File.write!(@css_file, "")
+      File.write!(@color_scheme_file, ":root { --primary: #000; }")
+
+      CSSPatcher.patch(@css_file, @color_scheme_file)
+
+      patched_content = File.read!(@css_file)
+      assert patched_content =~ "@layer base {"
+      assert patched_content =~ ":root { --primary: #000; }"
+      assert patched_content =~ "body {"
+      assert patched_content =~ "@apply bg-background text-foreground;"
+    end
+
+    test "patch/2 appends to existing body selector" do
+      initial_content = """
+      body {
+        margin: 0;
+      }
+      """
+
+      File.write!(@css_file, initial_content)
+      File.write!(@color_scheme_file, ":root { --primary: #000; }")
+
+      CSSPatcher.patch(@css_file, @color_scheme_file)
+
+      patched_content = File.read!(@css_file)
+      assert patched_content =~ "body {"
+      assert patched_content =~ "margin: 0;"
+      assert patched_content =~ "@apply bg-background text-foreground;"
+    end
+
+    test "patch/2 doesn't duplicate body tweaks" do
+      initial_content = """
+      body {
+        @apply bg-background text-foreground;
+      }
+      """
+
+      File.write!(@css_file, initial_content)
+      File.write!(@color_scheme_file, ":root { --primary: #000; }")
+
+      CSSPatcher.patch(@css_file, @color_scheme_file)
+
+      patched_content = File.read!(@css_file)
+      assert patched_content =~ "body {"
+      assert patched_content =~ "@apply bg-background text-foreground;"
+
+      refute String.contains?(
+               patched_content,
+               "@apply bg-background text-foreground;\n  @apply bg-background text-foreground;"
+             )
+    end
+
+    test "patch/2 inserts after @import statements" do
+      initial_content = """
+      @import 'tailwindcss/base';
+      @import 'tailwindcss/components';
+      @import 'tailwindcss/utilities';
+      """
+
+      File.write!(@css_file, initial_content)
+      File.write!(@color_scheme_file, ":root { --primary: #000; }")
+
+      CSSPatcher.patch(@css_file, @color_scheme_file)
+
+      patched_content = File.read!(@css_file)
+      [imports, rest] = String.split(patched_content, "@import 'tailwindcss/utilities';")
+      assert imports =~ "@import 'tailwindcss/base';"
+      assert imports =~ "@import 'tailwindcss/components';"
+      assert rest =~ "body {"
+      assert rest =~ "@layer base {"
+    end
+  end
+end

--- a/test/salad_ui/patcher/js_patcher_test.exs
+++ b/test/salad_ui/patcher/js_patcher_test.exs
@@ -1,0 +1,56 @@
+defmodule SaladUI.Patcher.JSPatcherTest do
+  use ExUnit.Case
+
+  alias SaladUI.Patcher.JSPatcher
+
+  @temp_dir "test/temp"
+  @js_file "#{@temp_dir}/app.js"
+  @code_to_add_file "#{@temp_dir}/code_to_add.js"
+
+  setup do
+    File.mkdir_p!(@temp_dir)
+    on_exit(fn -> File.rm_rf!(@temp_dir) end)
+  end
+
+  describe "Test JS patcher" do
+    test "patch/2 adds new code when JS file is empty" do
+      File.write!(@js_file, "")
+      File.write!(@code_to_add_file, "console.log('Hello, SaladUI!');")
+
+      JSPatcher.patch(@js_file, @code_to_add_file)
+
+      patched_content = File.read!(@js_file)
+      assert patched_content =~ "// Allows to execute JS commands from the server"
+      assert patched_content =~ "console.log('Hello, SaladUI!');"
+    end
+
+    test "patch/2 appends new code to existing content" do
+      initial_content = "const app = {};"
+      File.write!(@js_file, initial_content)
+      File.write!(@code_to_add_file, "console.log('Hello, SaladUI!');")
+
+      JSPatcher.patch(@js_file, @code_to_add_file)
+
+      patched_content = File.read!(@js_file)
+      assert patched_content =~ initial_content
+      assert patched_content =~ "// Allows to execute JS commands from the server"
+      assert patched_content =~ "console.log('Hello, SaladUI!');"
+    end
+
+    test "patch/2 doesn't duplicate code if it already exists" do
+      initial_content = """
+      const app = {};
+      // Allows to execute JS commands from the server
+      console.log('Hello, SaladUI!');
+      """
+
+      File.write!(@js_file, initial_content)
+      File.write!(@code_to_add_file, "console.log('Hello, SaladUI!');")
+
+      JSPatcher.patch(@js_file, @code_to_add_file)
+
+      patched_content = File.read!(@js_file)
+      assert patched_content == initial_content
+    end
+  end
+end

--- a/test/salad_ui/patcher/tailwind_patcher_test.exs
+++ b/test/salad_ui/patcher/tailwind_patcher_test.exs
@@ -1,0 +1,123 @@
+defmodule SaladUI.Patcher.TailwindPatcherTest do
+  use ExUnit.Case
+
+  alias SaladUI.Patcher.TailwindPatcher
+
+  @temp_dir "test/temp"
+  @tailwind_config "#{@temp_dir}/tailwind.config.js"
+
+  setup do
+    File.mkdir_p!(@temp_dir)
+    on_exit(fn -> File.rm_rf!(@temp_dir) end)
+  end
+
+  describe "Test Tailwind CSS config patcher" do
+    test "patch/1 adds plugins when missing" do
+      initial_content = "module.exports = {}"
+      File.write!(@tailwind_config, initial_content)
+
+      TailwindPatcher.patch(@tailwind_config)
+
+      patched_content = File.read!(@tailwind_config)
+      assert patched_content =~ "plugins: ["
+      assert patched_content =~ "require(\"@tailwindcss/typography\")"
+      assert patched_content =~ "require(\"tailwindcss-animate\")"
+    end
+
+    test "patch/1 doesn't duplicate existing plugins" do
+      initial_content = """
+      module.exports = {
+        plugins: [
+          require("@tailwindcss/typography"),
+          require("tailwindcss-animate")
+        ]
+      }
+      """
+
+      File.write!(@tailwind_config, initial_content)
+
+      TailwindPatcher.patch(@tailwind_config)
+
+      patched_content = File.read!(@tailwind_config)
+
+      assert patched_content =~ "require(\"@tailwindcss/typography\")"
+      assert patched_content =~ "require(\"tailwindcss-animate\")"
+
+      # Count occurrences of each plugin
+      typography_count = patched_content |> String.split("@tailwindcss/typography") |> length() |> Kernel.-(1)
+      animate_count = patched_content |> String.split("tailwindcss-animate") |> length() |> Kernel.-(1)
+
+      assert typography_count == 1
+      assert animate_count == 1
+    end
+
+    test "patch/1 adds theme and colors config when missing" do
+      initial_content = "module.exports = {}"
+      File.write!(@tailwind_config, initial_content)
+
+      TailwindPatcher.patch(@tailwind_config)
+
+      patched_content = File.read!(@tailwind_config)
+      assert patched_content =~ "theme: {"
+      assert patched_content =~ "extend: {"
+      assert patched_content =~ "colors: require(\"./tailwind.colors.json\")"
+    end
+
+    test "patch/1 updates existing colors config" do
+      initial_content = """
+      module.exports = {
+        theme: {
+          extend: {
+            colors: {
+              primary: '#000000'
+            }
+          }
+        }
+      }
+      """
+
+      File.write!(@tailwind_config, initial_content)
+
+      TailwindPatcher.patch(@tailwind_config)
+
+      patched_content = File.read!(@tailwind_config)
+      assert patched_content =~ "colors: require(\"./tailwind.colors.json\")"
+      refute patched_content =~ "primary: '#000000'"
+    end
+
+    test "patch/1 doesn't duplicate theme and colors config" do
+      initial_content = """
+      module.exports = {
+        theme: {
+          extend: {
+            colors: require("./tailwind.colors.json")
+          }
+        }
+      }
+      """
+
+      File.write!(@tailwind_config, initial_content)
+
+      TailwindPatcher.patch(@tailwind_config)
+
+      patched_content = File.read!(@tailwind_config)
+
+      assert patched_content =~ """
+               theme: {
+                 extend: {
+                   colors: require("./tailwind.colors.json")
+                 }
+               }
+             """
+
+      # Count ocurrences
+      theme_count = patched_content |> String.split("theme: {") |> length() |> Kernel.-(1)
+      expand_count = patched_content |> String.split("extend: {") |> length() |> Kernel.-(1)
+      colors_count = patched_content |> String.split("colors: require") |> length() |> Kernel.-(1)
+
+      assert theme_count == 1
+      assert expand_count == 1
+      assert colors_count == 1
+    end
+  end
+end

--- a/test/support/mix_task_case.ex
+++ b/test/support/mix_task_case.ex
@@ -1,0 +1,63 @@
+defmodule SaladUI.Test.MixTaskCase do
+  @moduledoc """
+  This module provides helper functions for testing Mix tasks.
+  """
+
+  use ExUnit.CaseTemplate
+
+  using do
+    quote do
+      import SaladUI.Test.MixTaskCase
+    end
+  end
+
+  setup do
+    # Get Mix output sent to the current
+    # process to avoid polluting tests.
+    Mix.shell(Mix.Shell.Process)
+
+    on_exit(fn ->
+      Mix.shell(Mix.Shell.IO)
+    end)
+
+    :ok
+  end
+
+  @doc """
+  Makes an assertion about the output of a mix task.
+  """
+  def assert_mix_output(t, desired_output) do
+    assert_received {:mix_shell, ^t, [^desired_output]}
+  end
+
+  @doc """
+  Makes a negative assertion about the output of a mix task.
+  """
+  def refute_mix_output(t, undesired_output) do
+    refute_received {:mix_shell, ^t, [^undesired_output]}
+  end
+
+  @doc """
+  Creates a temporary directory for testing file operations.
+  """
+  def in_tmp(which, function) do
+    base = Path.join([tmp_path(), random_string(10)])
+    path = Path.join([base, to_string(which)])
+
+    try do
+      File.rm_rf!(path)
+      File.mkdir_p!(path)
+      File.cd!(path, function)
+    after
+      File.rm_rf!(base)
+    end
+  end
+
+  def tmp_path do
+    Path.expand("../../tmp", __DIR__)
+  end
+
+  defp random_string(len) do
+    len |> :crypto.strong_rand_bytes() |> Base.url_encode64() |> binary_part(0, len)
+  end
+end


### PR DESCRIPTION
This pull request adds a CLI that allows users to set up the library and add components. The CLI consists of two Mix tasks: `salad.init` and `salad.add`.

## **salad.init**

https://github.com/user-attachments/assets/b0d9038f-2906-4ca0-9d82-ed2cfe82d2b8

This task automates the setup of **SaladUI** in an existing project. Users just have to run `mix salad.init` after installing the library to get the necessary configurations for **SaladUI** to work out of the box. This is done by patching existing configuration files using regular expressions. From a high-level perspective, this task performs the following:

- Updates the content of the `config.exs` file to add the [tails](https://github.com/zachdaniel/tails) configuration:
 ```bash
config :tails, colors_file: Path.join(File.cwd!(), "assets/tailwind.colors.json")
```
- Updates the content of the `dev.exs` file to include a configuration to specify where to install components. The CLI prompts the user for that path, with the default set to `lib/app_web/components/ui` (`app_web` is automatically replaced by the correct folder name in the user's project).
- Updates the content of the `app.css` file to include a `@layer base` directive with CSS variables for a color theme. The CLI prompts the user for a color theme, with the default set to gray. The available color themes are the same as those in [ShadCN](https://ui.shadcn.com/themes). Additionally, it adds some CSS tweaks to ensure that dark/light mode and border colors work correctly.
- Updates the content fo the `app.js` file to enable  execute client actions from server.
- Generates a `tailwind.colors.json` file.
- Updates the `tailwind.config.js` file to add the necessary plugins for **SaladUI** to function and includes a theme configuration that uses the previously generated `tailwind.colors.json` file.
- Generates a `helpers.ex` file with useful helpers for building UI components.
- Generates a `component.ex` file.
- Installs `tailwindcss-animate` as it is required.

## **salad.add**

https://github.com/user-attachments/assets/455f3179-7ba7-4760-8ae4-3afb9571a93b

This task adds a new component to the user's project, similar to ShadCN's CLI. You can pass multiple component names to the command, and it will add each of them. If you provide incorrect component names, the CLI will ignore them. Also, if you provide both incorrect component names and valid component names, the CLI will discard the invalid ones and prompt you to install the valid components. Invoking the task with the argument "all" installs all available components, while "help" prints a list of available components.

## Side note

If users install components in their project, it would be beneficial to provide an optional macro that allows them to auto-import all the components in their components path. They could then add it to their `live_view/0` function in the `AppWeb` module to automatically import all the components they have installed in live views. I am considering how this could be implemented.

## Summary by Sourcery

Add a CLI for setting up and managing SaladUI components, including tasks for initialization and component addition. Introduce a comprehensive set of color themes, along with tests to ensure functionality and reliability.

New Features:
- Introduce a CLI with Mix tasks `salad.init` and `salad.add`, to facilitate the setup and management of SaladUI components in a project.
- Add the `salad.init` task to automate the setup of SaladUI, including configuration updates and necessary file generation.
- Implement the `salad.add` task to allow users to add new components to their project, with support for multiple components and error handling for invalid names.

Enhancements:
- Include a set of color themes and configurations to support theming and customization of the UI components.

Tests:
- Add tests for the TailwindPatcher, CSSPatcher, ConfigPatcher, and JSPatcher to ensure correct patching of configuration and source files.
- Implement tests for the Mix tasks `salad.init` and `salad.add` to verify their functionality and error handling.