### PR TITLE
Fix warnings on inputs

### DIFF
--- a/lib/salad_ui/input.ex
+++ b/lib/salad_ui/input.ex
@@ -24,7 +24,9 @@ defmodule SaladUI.Input do
   attr :field, Phoenix.HTML.FormField, doc: "a form field struct retrieved from the form, for example: @form[:email]"
 
   attr :class, :string, default: nil
-  attr :rest, :global
+  attr :rest, :global,
+    include: ~w(accept autocomplete capture cols disabled form list max maxlength min minlength
+                multiple pattern placeholder readonly required rows size step)
 
   def input(assigns) do
     assigns = prepare_assign(assigns)


### PR DESCRIPTION
<img width="617" alt="image" src="https://github.com/user-attachments/assets/9c5ca7db-d74d-472d-9d6c-0c10f12812be">

## Summary by Sourcery

Bug Fixes:
- Fix warnings related to input attributes by explicitly specifying allowed global attributes.