### PR TITLE
fix: Explicitly include the <a> attributes to avoid lsp warning

### DIFF
--- a/lib/salad_ui/breadcrumb.ex
+++ b/lib/salad_ui/breadcrumb.ex
@@ -97,7 +97,7 @@ defmodule SaladUI.Breadcrumb do
   Render breadcrumb link
   """
   attr :class, :string, default: nil
-  attr :rest, :global
+  attr :rest, :global, include: ~w(download href hreflang ping referrerpolicy rel target type)
   slot :inner_block, required: true
 
   def breadcrumb_link(assigns) do


### PR DESCRIPTION
![image](https://github.com/user-attachments/assets/b8dab1ae-699c-493a-9665-80690655d49d)

In a similar vein to #57, there is a warning for the `breadcrumb_link` attribtute. Since it uses link under the hood which is an anchor tag, this PR explicitly adds the non experimental attributes of the anchor tag to the `includes`

This seems to work locally but I wasn't able to run the test suite for some reason. Both `mix test` and `mix deps` gets me this error.

```bash
{"init terminating in do_boot",{undef,[{elixir,start_cli,[],[]},{init,start_em,1,[]},{init,do_boot,3,[]}]}}
init terminating in do_boot ({undef,[{elixir,start_cli,[],[]},{init,start_em,1,[]},{init,do_boot,3,[]}]})

Crash dump is being written to: erl_crash.dump...done
```

## Summary by Sourcery

Bug Fixes:
- Explicitly include non-experimental attributes of the anchor tag in the breadcrumb link to avoid LSP warnings.