### PR TITLE
Improve patcher & init command

### DIFF
--- a/lib/mix/tasks/salad.add.ex
+++ b/lib/mix/tasks/salad.add.ex
@@ -90,7 +90,7 @@ defmodule Mix.Tasks.Salad.Add do
     module_name = get_module_name()
 
     source
-    |> String.replace(~r/defmodule SaladUI\.([a-zA-Z0-9_]+)/, "defmodule #{module_name}.Components.\\1")
+    |> String.replace(~r/defmodule SaladUI\.([a-zA-Z0-9_]+)/, "defmodule #{module_name}.Component.\\1")
     |> String.replace(~r/use SaladUI,\s*:component/, "use #{module_name}.Component")
   end
 

--- a/lib/salad_ui/input.ex
+++ b/lib/salad_ui/input.ex
@@ -24,8 +24,7 @@ defmodule SaladUI.Input do
   attr :field, Phoenix.HTML.FormField, doc: "a form field struct retrieved from the form, for example: @form[:email]"
 
   attr :class, :string, default: nil
-  attr :rest, :global,
-    include: ~w(accept autocomplete capture cols disabled form list max maxlength min minlength
+  attr :rest, :global, include: ~w(accept autocomplete capture cols disabled form list max maxlength min minlength
                 multiple pattern placeholder readonly required rows size step)
 
   def input(assigns) do

--- a/lib/salad_ui/patcher.ex
+++ b/lib/salad_ui/patcher.ex
@@ -34,8 +34,8 @@ defmodule SaladUI.Patcher do
 
   - tailwind_config_path: Path to the Tailwind configuration file
   """
-  def patch_tailwind_config(tailwind_config_path) do
-    TailwindPatcher.patch(tailwind_config_path)
+  def patch_tailwind_config(tailwind_config_path, opts \\ []) do
+    TailwindPatcher.patch(tailwind_config_path, opts)
   end
 
   @doc """

--- a/lib/salad_ui/tasks_helpers.ex
+++ b/lib/salad_ui/tasks_helpers.ex
@@ -16,7 +16,7 @@ defmodule SaladUi.TasksHelpers do
     if Mix.env() == :test, do: test_path(), else: development_path()
   end
 
-  defp test_path, do: Path.expand("lib/salad_ui")
+  defp test_path, do: __DIR__
 
   defp development_path do
     case find_salad_ui_dep() do

--- a/priv/templates/component.eex
+++ b/priv/templates/component.eex
@@ -15,7 +15,7 @@ defmodule <%= @module_name %>Web.Component do
     quote do
       use Phoenix.Component
 
-      import <%= @module_name %>Web.Helpers
+      import <%= @module_name %>Web.ComponentHelpers
       import Tails, only: [classes: 1]
 
       alias Phoenix.LiveView.JS

--- a/test/mix/salad.init_test.exs
+++ b/test/mix/salad.init_test.exs
@@ -4,7 +4,7 @@ defmodule Mix.Tasks.Salad.InitTest do
   alias Mix.Tasks.Salad.Init
 
   @tmp_dir "test_init"
-  @default_components_path Path.join([@tmp_dir, "lib/test_app_web/components/ui"])
+  @default_components_path Path.join(["lib/test_app_web/components"])
 
   setup do
     # The shell asks for a path to install components.
@@ -22,7 +22,7 @@ defmodule Mix.Tasks.Salad.InitTest do
   test "run/1 initializes SaladUI" do
     in_tmp(@tmp_dir, fn ->
       # Create a mock mix.exs file
-      File.write!("mix.exs", "defmodule TestApp.MixProject do use Mix.Project\nend")
+      File.write!("mix.exs", "defmodule SaladUI.MixProject do use Mix.Project\nend")
 
       File.mkdir_p!("config")
       File.mkdir_p!("assets/css")
@@ -35,12 +35,6 @@ defmodule Mix.Tasks.Salad.InitTest do
       File.write!("assets/js/app.js", "// Original app.js content\n")
       File.write!("assets/tailwind.config.js", "module.exports = {\n  // Original tailwind config\n}\n")
 
-      # Both helpers.ex and component.ex are created
-      # in a path built using the app name.
-      # In test, the app name is "salad_ui", so
-      # we need the path `salad_ui_web` and search those file in that path
-      File.mkdir_p!("lib/salad_ui_web")
-
       # Mock the _build directory structure
       priv_dir = "_build/test/lib/salad_ui/priv/static/assets"
       File.mkdir_p!(priv_dir)
@@ -49,12 +43,7 @@ defmodule Mix.Tasks.Salad.InitTest do
       File.mkdir_p!(Path.join(priv_dir, "colors"))
       File.write!(Path.join([priv_dir, "colors", "gray.css"]), "/* gray theme */")
 
-      # Mock a helper source file
-      File.mkdir_p!("lib/salad_ui")
-      File.write!("lib/salad_ui/helpers.ex", "defmodule TestAppWeb.Helpers do")
-
       Init.run([])
-
       # Allow some time for file operations to complete
       :timer.sleep(100)
 
@@ -72,8 +61,8 @@ defmodule Mix.Tasks.Salad.InitTest do
       assert File.read!("assets/js/app.js") =~ "// server events"
       assert File.exists?("assets/tailwind.colors.json")
       assert File.read!("assets/tailwind.config.js") =~ "require(\"./tailwind.colors.json\")"
-      assert File.read!("lib/salad_ui_web/helpers.ex") =~ "defmodule TestAppWeb.Helpers do"
-      assert File.read!("lib/salad_ui_web/component.ex") =~ "defmodule SaladUiWeb.Component do"
+      assert File.read!("lib/test_app_web/components/helpers.ex") =~ "defmodule SaladUiWeb.ComponentHelpers do"
+      assert File.read!("lib/test_app_web/components/component.ex") =~ "defmodule SaladUiWeb.Component do"
     end)
   end
 


### PR DESCRIPTION
Update command to support 
- salad.init support optíon `--as-lib` to install neccessary if user want to use salad_ui as a library

## Summary by Sourcery

Enhance the 'salad.init' command by adding a new '--as-lib' option to support using SaladUI as a library, and refactor the command for improved usability. Update tests to align with these changes.

New Features:
- Add support for the '--as-lib' option in the 'salad.init' command to configure SaladUI as a library.

Enhancements:
- Refactor the 'salad.init' command to improve its usability and flexibility, including changes to the default component path and module naming conventions.

Tests:
- Update tests for the 'salad.init' command to reflect changes in component paths and module names.