### PR TITLE
Implement popover component

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -30,3 +30,5 @@ salad_ui-*.tar
 node_modules/
 
 /.vscode/
+/.ctags.d/
+.tags

--- a/lib/salad_ui/popover.ex
+++ b/lib/salad_ui/popover.ex
@@ -1,0 +1,112 @@
+defmodule SaladUI.Popover do
+  @moduledoc """
+  Implement Popover component
+
+  ## Usage
+      <.popover>
+        <.popover_trigger target="my-id">
+          <.button variant="link">
+            @salad_ui
+          </.button>
+        </.popover_trigger>
+        <.popover_content id="my-id" side="left">
+           Hover card content
+        </.popover_content>
+      </.popover>
+  """
+  use SaladUI, :component
+
+  @doc """
+  Render popover wrapper
+  """
+  attr :class, :string, default: nil
+  attr :rest, :global
+  slot :inner_block, required: true
+
+  def popover(assigns) do
+    ~H"""
+    <div
+      class={
+        classes([
+          "inline-block relative",
+          @class
+        ])
+      }
+      {@rest}
+    >
+      <%= render_slot(@inner_block) %>
+    </div>
+    """
+  end
+
+  @doc """
+  Render popover trigger
+  """
+  attr :class, :string, default: nil
+  attr :target, :string, required: true,
+       doc: "The id of target element to show popover"
+  attr :rest, :global
+  slot :inner_block, required: true
+
+  def popover_trigger(assigns) do
+    ~H"""
+    <div
+      class={
+        classes([
+          "",
+          @class
+        ])
+      }
+      phx-click={toggle_target(@target)}
+      {@rest}
+    >
+      <%= render_slot(@inner_block) %>
+    </div>
+    """
+  end
+
+  @doc """
+  Render popover content
+  """
+  attr :class, :string, default: nil
+  attr :side, :string, values: ~w(bottom left right top), default: "top"
+  attr :align, :string, values: ["start", "center", "end"], default: "center"
+  attr :open, :boolean, default: false
+  attr :rest, :global
+  slot :inner_block, required: true
+
+  def popover_content(assigns) do
+    assigns =
+      assign(assigns, :variant_class, side_variant(assigns.side, assigns.align))
+   |> assign_new(:state, fn -> if assigns[:open] in ["true", true] do "open" else "closed" end  end)
+
+
+    ~H"""
+    <div
+      data-side={@side}
+      data-state={@state}
+      phx-click-away={hide()}
+      class={
+        classes([
+          "absolute block",
+          "z-50 w-72 rounded-md border bg-popover p-4 text-popover-foreground shadow-md outline-none animate-in fade-in-0 zoom-in-95 data-[side=bottom]:slide-in-from-top-2 data-[side=left]:slide-in-from-right-2 data-[side=right]:slide-in-from-left-2 data-[side=top]:slide-in-from-bottom-2 data-[state=closed]:hidden",
+          @variant_class,
+          @class
+        ])
+      }
+      {@rest}
+    >
+      <%= render_slot(@inner_block) %>
+    </div>
+    """
+  end
+
+  defp toggle_target(id) do
+    JS.toggle_attribute({"data-state", "open", "closed"}, to: "##{id}")
+  end
+
+  defp hide() do
+    JS.set_attribute({"data-state", "closed"})
+  end
+
+end

--- a/test/salad_ui/popover_test.exs
+++ b/test/salad_ui/popover_test.exs
@@ -1,0 +1,86 @@
+defmodule SaladUI.PopoverTest do
+  use ComponentCase
+
+  import SaladUI.Button
+  import SaladUI.Popover
+
+  describe "test popover" do
+    test "popover_trigger" do
+      assigns = %{}
+
+      html =
+        ~H"""
+        <.popover_trigger class="text-green-500" target="xxx-id">Popover</.popover_trigger>
+        """
+        |> rendered_to_string()
+        |> clean_string()
+
+      assert html =~ ~r/<div class=\"text-green-500\".+Popover<\/div>/
+    end
+
+    test "popover_content top" do
+      assigns = %{}
+
+      html =
+        ~H"""
+        <.popover_content>Popover Content</.popover_content>
+        """
+        |> rendered_to_string()
+        |> clean_string()
+
+      assert html =~
+               "<div data-side=\"top\" data-state=\"closed\" phx-click-away=\"[[&quot;set_attr&quot;,{&quot;attr&quot;:[&quot;data-state&quot;,&quot;closed&quot;]}]]\" class=\"absolute block p-4 mb-2 rounded-md bg-popover text-popover-foreground outline-none shadow-md z-50 left-1/2 bottom-full w-72 -translate-x-1/2 animate-in border data-[side=bottom]:slide-in-from-top-2 data-[side=left]:slide-in-from-right-2 data-[side=right]:slide-in-from-left-2 data-[side=top]:slide-in-from-bottom-2 data-[state=closed]:hidden fade-in-0 slide-in-from-left-1/2 zoom-in-95\">Popover Content</div>"
+    end
+
+    test "It renders popover_content bottom correctly" do
+      assigns = %{}
+
+      html =
+        ~H"""
+        <.popover_content side="bottom">Popover Content</.popover_content>
+        """
+        |> rendered_to_string()
+        |> clean_string()
+
+      assert html =~
+               "<div data-side=\"bottom\" data-state=\"closed\" phx-click-away=\"[[&quot;set_attr&quot;,{&quot;attr&quot;:[&quot;data-state&quot;,&quot;closed&quot;]}]]\" class=\"absolute block p-4 mt-2 rounded-md bg-popover text-popover-foreground outline-none shadow-md z-50 left-1/2 top-full w-72 -translate-x-1/2 animate-in border data-[side=bottom]:slide-in-from-top-2 data-[side=left]:slide-in-from-right-2 data-[side=right]:slide-in-from-left-2 data-[side=top]:slide-in-from-bottom-2 data-[state=closed]:hidden fade-in-0 slide-in-from-left-1/2 zoom-in-95\">Popover Content</div>"
+    end
+
+    test "It renders popover_content right correctly" do
+      assigns = %{}
+
+      html =
+        ~H"""
+        <.popover_content side="right">Popover Content</.popover_content>
+        """
+        |> rendered_to_string()
+        |> clean_string()
+
+      assert html =~
+               "<div data-side=\"right\" data-state=\"closed\" phx-click-away=\"[[&quot;set_attr&quot;,{&quot;attr&quot;:[&quot;data-state&quot;,&quot;closed&quot;]}]]\" class=\"absolute block p-4 ml-2 rounded-md bg-popover text-popover-foreground outline-none shadow-md z-50 left-full top-1/2 w-72 -translate-y-1/2 animate-in border data-[side=bottom]:slide-in-from-top-2 data-[side=left]:slide-in-from-right-2 data-[side=right]:slide-in-from-left-2 data-[side=top]:slide-in-from-bottom-2 data-[state=closed]:hidden fade-in-0 slide-in-from-top-1/2 zoom-in-95\">Popover Content</div>"
+    end
+
+    test "It renders popover correctly" do
+      assigns = %{}
+
+      html =
+        ~H"""
+        <.popover>
+          <.popover_trigger target="content-id">
+            <.button variant="link">
+              @salad_ui
+            </.button>
+          </.popover_trigger>
+
+          <.popover_content id="content-id">
+            Hover card content
+          </.popover_content>
+        </.popover>
+        """
+        |> rendered_to_string()
+        |> clean_string()
+
+      assert html =~ "div class=\"relative inline-block\"><div class=\"\" phx-click=\"[[&quot;toggle_attr&quot;,{&quot;attr&quot;:[&quot;data-state&quot;,&quot;open&quot;,&quot;closed&quot;],&quot;to&quot;:&quot;#content-id&quot;}]]\"><button class=\"inline-flex px-4 py-2 rounded-md text-primary transition-colors whitespace-nowrap items-center justify-center font-medium underline-offset-4 text-sm h-9 hover:underline focus-visible:ring-ring focus-visible:outline-none focus-visible:ring-1 disabled:pointer-events-none disabled:opacity-50\">@salad_ui</button></div><div data-side=\"top\" data-state=\"closed\" phx-click-away=\"[[&quot;set_attr&quot;,{&quot;attr&quot;:[&quot;data-state&quot;,&quot;closed&quot;]}]]\" class=\"absolute block p-4 mb-2 rounded-md bg-popover text-popover-foreground outline-none shadow-md z-50 left-1/2 bottom-full w-72 -translate-x-1/2 animate-in border data-[side=bottom]:slide-in-from-top-2 data-[side=left]:slide-in-from-right-2 data-[side=right]:slide-in-from-left-2 data-[side=top]:slide-in-from-bottom-2 data-[state=closed]:hidden fade-in-0 slide-in-from-left-1/2 zoom-in-95\" id=\"content-id\">Hover card content</div></div>"
+    end
+  end
+end


### PR DESCRIPTION
Some animation is tripped out because of limitation of pure css animation here

Here is an example of popover copied from storybook

```heex
<.popover>
  <.popover_trigger target="popover-single-popover">
    <.button variant="outline">
      Open popover
    </.button>
  </.popover_trigger>
  <.popover_content class="w-80" side="top">
    <div class="grid gap-4">
      <div class="space-y-2">
        <h4 class="font-medium leading-none">
          Dimensions
        </h4>
    </div>
  </.popover_content>
</.popover>
```

## Summary by Sourcery

Implement a new Popover component with customizable triggers and content, and add tests to ensure its functionality across different configurations.

New Features:
- Introduce a new Popover component that allows users to create interactive popover elements with customizable triggers and content.

Tests:
- Add comprehensive tests for the Popover component, including tests for different content positions (top, bottom, right) and trigger functionality.