### PR TITLE
Fix component.eex docs

### DIFF
--- a/priv/templates/component.eex
+++ b/priv/templates/component.eex
@@ -4,7 +4,7 @@ defmodule <%= @module_name %>Web.Component do
 
   This can be used in your components as:
 
-    use <%= @module_name %>Web
+    use <%= @module_name %>Web.Component
 
   Do NOT define functions inside the quoted expressions
   below. Instead, define additional modules and import


### PR DESCRIPTION
Just a small correction: in the documentation for the `component.eex` file, it should say `use <%= @module_name %>Web.Component` instead of `use <%= @module_name %>Web`.

## Summary by Sourcery

Documentation:
- Correct the usage example in the component.eex documentation to reflect the correct module name.