### PR TITLE
Improvements to the chart component

### DIFF
--- a/lib/mix/tasks/salad.add.ex
+++ b/lib/mix/tasks/salad.add.ex
@@ -97,10 +97,7 @@ defmodule Mix.Tasks.Salad.Add do
   end
 
   defp maybe_apply_additional_insertions(source, module_name, "chart") do
-    source
-    |> String.replace("use Phoenix.LiveComponent", "use #{module_name}, :live_component")
-    |> String.replace("use Phoenix.LiveView", "use #{module_name}, :live_view")
-    |> String.replace("SaladUI.Chart", "#{module_name}.Component.Chart")
+    String.replace(source, "SaladUI.LiveChart", "#{module_name}.Component.LiveChart")
   end
 
   defp maybe_apply_additional_insertions(source, _, _), do: source

--- a/lib/salad_ui/chart.ex
+++ b/lib/salad_ui/chart.ex
@@ -1,88 +1,42 @@
 defmodule SaladUI.LiveChart do
-  @moduledoc """
-  The entrypoint for creating a chart component.
+  @moduledoc false
 
-  A chart is created by defining a module that uses this one:
+  use Phoenix.LiveComponent
 
-  ```elixir
-  defmodule MyChart do
-    use SaladUI.Chart
-
-    def render(assigns) do
-      ~H\"\"\"
-        <div>
-          <.chart id={@id} chart_config={@chart_config} chart_data={@chart_data} />
-        </div>
-      \"\"\"
-    end
-  ```
-
-  Then, in your live view, you can use the chart like this:
-
-  ```elixir
-  defmodule MyChartLive do
-    use Phoenix.LiveView
-
-    @chart_config %{
-      labels: ["Jan", "Feb", "Mar", "Apr", "May", "Jun", "Jul", "Aug", "Sep", "Oct", "Nov", "Dec"],
-      type: "line",
-      options: %{
-        responsive: true
-      },
-      desktop: %{
-        label: "Desktop",
-        boderColor: hsl(var(--chart-1))
-      },
-      mobile: %{
-        label: "Mobile",
-        boderColor: hsl(var(--chart-2))
-      }
-    }
-
-    @chart_data [
-      %{desktop: 10, mobile: 20},
-      %{desktop: 20, mobile: 10},
-      %{desktop: 30, mobile: 10},
-      %{desktop: 40, mobile: 80},
-      %{desktop: 50, mobile: 20},
-      %{desktop: 60, mobile: 90},
-      %{desktop: 70, mobile: 30},
-      %{desktop: 80, mobile: 30},
-      %{desktop: 90, mobile: 40},
-      %{desktop: 100, mobile: 50},
-      %{desktop: 110, mobile: 60},
-      %{desktop: 90, mobile: 80}
-    ]
-
-    def mount(params, session, socket) do
-      socket =
-        socket
-        |> assign(chart_config: @chart_config)
-        |> assign(chart_data: @chart_data)
-
-      {:ok, socket}
-    end
-
-    def render(assigns) do
-      ~H\"\"\"
-        <.live_component
-          module={MyChart}
-          id="my-chart"
-          chart_config={@chart_config}
-          chart_data={@chart_data}
-        />
-      \"\"\"
-    end
+  @impl true
+  def render(assigns) do
+    ~H"""
+    <canvas
+      id={@id}
+      phx-hook="ChartHook"
+      data-chartconfig={Jason.encode!(@chart_config)}
+      role="img"
+      aria-label={@name}
+    >
+    </canvas>
+    """
   end
-  ```
 
-  Any module that uses `SaladUI.Chart` will be converted to a Phoenix's live component and will have an `update/2` callback to automatically update the chart on data changes. Also, a `.chart` component will be available to render the chart.
+  @impl true
+  def update(%{id: id, chart_data: chart_data} = assigns, socket) do
+    socket =
+      socket
+      |> assign(assigns)
+      |> push_event("update-chart-#{id}", %{data: chart_data})
 
-  This component requires a client hook called `ChartHook` to work. The hook is responsable to initialize and manage the entire life-cycle of a chart and render it, using a chart library for that. `SaladUI` comes with [Chart.js](https://www.chartjs.org/) as default, but you can rewrite `ChartHook` to integrate another chart libary.
+    {:ok, socket}
+  end
+end
+
+defmodule SaladUI.Chart do
+  @moduledoc """
+  Chart component.
+
+  This component displays a chart using a live component for real-time updates. Data and configuration are passed as attributes, and the rendering is managed on the client side through a hook called `ChartHook`. This hook initializes, manages the lifecycle, and renders the chart using a chart library. `SaladUI` comes with [Chart.js](https://www.chartjs.org/) as default, but you can rewrite `ChartHook` to integrate another chart library.
 
   ## Chart config
 
-  The `chart_config` map defines the chart's appearance and behavior:
+  The `chart_config` map defines the appearance and behavior of the chart:
 
   - Special keys
     - `labels`: A list of labels for the x-axis
@@ -120,38 +74,9 @@ defmodule SaladUI.LiveChart do
   All data points that do not match any datasets will be ignored.
   """
   use SaladUI, :component
-  use Phoenix.LiveComponent
 
-  @impl true
-  def render(assigns) do
-    ~H"""
-    <canvas
-      id={@id}
-      phx-hook="ChartHook"
-      data-chartconfig={Jason.encode!(@chart_config)}
-      role="img"
-      aria-label={@name}
-    >
-    </canvas>
-    """
-  end
-
-  @impl true
-  def update(%{id: id, chart_data: chart_data} = assigns, socket) do
-    socket =
-      socket
-      |> assign(assigns)
-      |> push_event("update-chart-#{id}", %{data: chart_data})
-
-    {:ok, socket}
-  end
-end
-
-defmodule SaladUI.Chart do
-  use SaladUI, :component
-
-  attr :id, :string, default: nil
-  attr :name, :string, default: nil
+  attr :id, :string, required: true
+  attr :name, :string, default: "", doc: "name of the chart for screen readers"
   attr :chart_config, :map, required: true
   attr :chart_data, :map, required: true
 


### PR DESCRIPTION
This PR updates the `salad.add` task to work with implemented in #70 and also updates the chart component documentation accordingly, fixing some issues along the way.

When the chart component is installed in user projects, the CLI replaces `use Phoenix.LiveComponent` with `use AppWeb, :live_component` in the `LiveChart` module. This leads to compilation errors if users try to import the chart component into their `html_helpers/0` function within the `AppWeb` module. To fix this, I adjusted the CLI so it no longer replaces `use Phoenix.LiveComponent`.

## Summary by Sourcery

Refactor the SaladUI.LiveChart module to streamline its implementation and update the associated documentation. Adjust the CLI to prevent incorrect replacements that lead to compilation errors.

Enhancements:
- Refactor the SaladUI.LiveChart module to simplify its implementation and improve maintainability by removing redundant code and consolidating functionality.

Documentation:
- Update the chart component documentation to reflect the changes in the module usage and configuration.

Chores:
- Adjust the CLI to prevent replacement of 'use Phoenix.LiveComponent' with 'use AppWeb, :live_component' to avoid compilation errors.