### PR TITLE
Accessibility hook

### DIFF
--- a/lib/mix/tasks/salad.init.ex
+++ b/lib/mix/tasks/salad.init.ex
@@ -45,6 +45,7 @@ defmodule Mix.Tasks.Salad.Init do
          :ok <- patch_css(color_scheme, assets_path),
          :ok <- patch_js(assets_path),
          :ok <- copy_tailwind_colors(assets_path),
+         :ok <- copy_zag_files(assets_path),
          :ok <- patch_tailwind_config(opts),
          :ok <- maybe_write_helpers_module(component_path, app_name, opts),
          :ok <- maybe_write_component_module(component_path, app_name, opts),
@@ -151,6 +152,25 @@ defmodule Mix.Tasks.Salad.Init do
     unless File.exists?(target_path) do
       File.cp!(source_path, target_path)
     end
+
+    :ok
+  end
+
+  defp copy_zag_files(assets_path) do
+    Mix.shell().info("Copying zag files to assets folder")
+    source_path = Path.join(assets_path, "zag")
+    target_path = Path.join(File.cwd!(), "assets/js/zag")
+
+    File.mkdir_p!(target_path)
+
+    Enum.each(File.ls!(source_path), fn file ->
+      unless File.exists?(Path.join(target_path, file)) do
+        File.cp!(Path.join(source_path, file), Path.join(target_path, file))
+      end
+    end)
+
+    Mix.shell().info("\nZagHook installed successfully")
+    Mix.shell().info("Do not forget to import it into your app.js file and pass it to your live socket")
 
     :ok
   end

--- a/lib/salad_ui/helpers.ex
+++ b/lib/salad_ui/helpers.ex
@@ -123,6 +123,13 @@ defmodule SaladUI.Helpers do
     "#{shared_classes} #{variation_classes}"
   end
 
+  def unique_id(seed \\ 16, length \\ 22) do
+    seed
+    |> :crypto.strong_rand_bytes()
+    |> Base.url_encode64()
+    |> binary_part(0, length)
+  end
+
   # Translate error message
   # borrowed from https://github.com/petalframework/petal_components/blob/main/lib/petal_components/field.ex#L414
   defp translate_error({msg, opts}) do

--- a/priv/static/assets/zag/ZagHook.js
+++ b/priv/static/assets/zag/ZagHook.js
@@ -1,0 +1,213 @@
+import * as componentsModules from "./index";
+import { camelize, getBooleanOption, getOption, normalizeProps } from "./utils";
+
+class Component {
+  el;
+  context;
+  service;
+  api;
+  cleanupFunctions = new Map();
+
+  constructor(el, context) {
+    this.el = el;
+    this.context = context;
+  }
+
+  init() {
+    this.initializeComponent();
+    this.render();
+
+    // Re-render on state updates
+    this.service.subscribe(() => {
+      this.api = this.initApi(this.componentModule);
+      this.render();
+    });
+
+    this.service.start();
+  }
+
+  initializeComponent() {
+    const componentName = this.el.dataset.component;
+
+    if (!componentName || !componentsModules[componentName]) {
+      console.error(`Component "${componentName}" not found.`);
+      return;
+    }
+
+    this.componentModule = componentsModules[componentName];
+    this.service = this.initService(this.componentModule, this.context);
+    this.api = this.initApi(this.componentModule);
+  }
+
+  destroy() {
+    this.service.stop();
+    this.cleanup();
+  }
+
+  cleanup() {
+    for (const cleanupFn of this.cleanupFunctions.values()) {
+      cleanupFn();
+    }
+    this.cleanupFunctions.clear();
+  }
+
+  parts(el) {
+    try {
+      return JSON.parse(el.dataset.parts || "[]");
+    } catch (error) {
+      console.error("Error parsing parts:", error);
+      return [];
+    }
+  }
+
+  initService(component, context) {
+    return component.machine(context);
+  }
+
+  initApi(component) {
+    return component.connect(
+      this.service.state,
+      this.service.send,
+      normalizeProps
+    );
+  }
+
+  render() {
+    this.cleanup();
+
+    for (const part of ["root", ...this.parts(this.el)]) {
+      this.renderPart(this.el, part, this.api);
+    }
+
+    for (const item of this.el.querySelectorAll("[data-part='item']")) {
+      this.renderItem(item);
+    }
+  }
+
+  renderPart(root, name, api, opts = {}) {
+    const part =
+      name === "root" ? root : root.querySelector(`[data-part='${name}']`);
+
+    const getterName = `get${camelize(name, true)}Props`;
+
+    if (part && api[getterName]) {
+      const cleanup = this.spreadProps(part, api[getterName](opts));
+      this.cleanupFunctions.set(part, cleanup);
+    }
+  }
+
+  renderItem(item) {
+    const value = item.dataset.value;
+    if (!value) {
+      console.error("Missing `data-value` attribute on item.");
+      return;
+    }
+
+    const cleanup = this.spreadProps(item, this.api.getItemProps({ value }));
+    this.cleanupFunctions.set(item, cleanup);
+
+    for (const part of this.parts(item)) {
+      this.renderPart(item, `item-${part}`, this.api, { value });
+    }
+  }
+
+  spreadProps(el, attrs) {
+    const oldAttrs = el;
+    const prevAttrsMap = new WeakMap();
+    const attrKeys = Object.keys(attrs);
+
+    const addEvent = (event, callback) => {
+      el.addEventListener(event.toLowerCase(), callback);
+    };
+
+    const removeEvent = (event, callback) => {
+      el.removeEventListener(event.toLowerCase(), callback);
+    };
+
+    const setup = (attr) => addEvent(attr.substring(2), attrs[attr]);
+    const teardown = (attr) => removeEvent(attr.substring(2), attrs[attr]);
+
+    const apply = (attrName) => {
+      // avoid overriding element's id because LiveView will lose
+      // track of it and DOM patching will not work as expected
+      if (attrName === "id") return;
+
+      let value = attrs[attrName];
+      const oldValue = oldAttrs[attrName];
+      if (value === oldValue) return;
+
+      if (typeof value === "boolean") value = value || undefined;
+
+      if (value != null) {
+        if (["value", "checked", "htmlFor", "id"].includes(attrName)) {
+          el[attrName] = value;
+        } else {
+          el.setAttribute(attrName.toLowerCase(), value);
+        }
+      } else {
+        el.removeAttribute(attrName.toLowerCase());
+      }
+    };
+
+    attrKeys.forEach((key) => {
+      if (key.startsWith("on")) setup(key);
+      else apply(key);
+    });
+
+    prevAttrsMap.set(el, attrs);
+
+    return () => {
+      attrKeys.filter((key) => key.startsWith("on")).forEach(teardown);
+    };
+  }
+}
+
+export default {
+  mounted() {
+    try {
+      this.component = new Component(this.el, this.context());
+      this.component.init();
+    } catch (error) {
+      console.error("Error mounting component:", error);
+    }
+  },
+
+  destroyed() {
+    try {
+      this.component.destroy();
+    } catch (error) {
+      console.error("Error destroying component:", error);
+    }
+  },
+
+  context() {
+    try {
+      const options = this.el.dataset.options
+        ? Object.fromEntries(
+            Object.entries(JSON.parse(this.el.dataset.options)).map(
+              ([key, value]) => [
+                camelize(key),
+                value === "bool"
+                  ? getBooleanOption(this.el, key)
+                  : getOption(this.el, key, value),
+              ]
+            )
+          )
+        : {};
+
+      const listeners = this.el.dataset.listeners
+        ? JSON.parse(this.el.dataset.listeners)
+            .map((event) => ({
+              [`on${camelize(event, true)}Change`]: (details) =>
+                this.pushEvent(event, details),
+            }))
+            .reduce((acc, listener) => ({ ...acc, ...listener }), {})
+        : {};
+
+      return { id: this.el.id || "", ...options, ...listeners };
+    } catch (error) {
+      console.error("Error parsing context:", error);
+      return {};
+    }
+  },
+};

--- a/priv/static/assets/zag/utils.js
+++ b/priv/static/assets/zag/utils.js
@@ -1,0 +1,72 @@
+import { createNormalizer } from "@zag-js/types";
+
+const propMap = {
+  onFocus: "onFocusin",
+  onBlur: "onFocusout",
+  onChange: "onInput",
+  onDoubleClick: "onDblclick",
+  htmlFor: "for",
+  className: "class",
+  defaultValue: "value",
+  defaultChecked: "checked",
+};
+
+export const camelize = (str, capitalizeFirst = false) => {
+  return str
+    .toLowerCase()
+    .replace(/[-_](.)/g, (_match, letter) => letter.toUpperCase())
+    .replace(/^(.)/, (_match, firstLetter) =>
+      capitalizeFirst ? firstLetter.toUpperCase() : firstLetter
+    );
+};
+
+export const getOption = (el, name, validOptions) => {
+  const kebabName = name.replace(/([a-z])([A-Z])/g, "$1-$2").toLowerCase();
+  let initial = el.dataset[kebabName];
+
+  if (
+    validOptions &&
+    initial !== undefined &&
+    !validOptions.includes(initial)
+  ) {
+    console.error(
+      `Invalid '${name}' specified: '${initial}'. Expected one of '${validOptions.join(
+        "', '"
+      )}'.`
+    );
+    initial = undefined;
+  }
+
+  return initial;
+};
+
+export const getBooleanOption = (el, name) => {
+  const kebabName = name.replace(/([a-z])([A-Z])/g, "$1-$2").toLowerCase();
+  return el.dataset[kebabName] === "true" || el.dataset[kebabName] === "";
+};
+
+export const normalizeProps = createNormalizer((props) => {
+  return Object.entries(props).reduce((acc, [key, value]) => {
+    if (value === undefined) return acc;
+    key = propMap[key] || key;
+
+    if (key === "style" && typeof value === "object") {
+      acc.style = toStyleString(value);
+    } else {
+      acc[key.toLowerCase()] = value;
+    }
+
+    return acc;
+  }, {});
+});
+
+export const toStyleString = (style) => {
+  return Object.entries(style).reduce((styleString, [key, value]) => {
+    if (value === null || value === undefined) return styleString;
+    const formattedKey = key.startsWith("--")
+      ? key
+      : key.replace(/[A-Z]/g, (match) => `-${match.toLowerCase()}`);
+
+    return `${styleString}${formattedKey}:${value};`;
+  }, "");
+};


### PR DESCRIPTION
This PR introduces a hook to integrate the [Zag ](https://zagjs.com) library with SaladUI components, inspired by @cschmatzler's work in [Turboprop](https://github.com/leuchtturm-dev/turboprop/).

Zag is a framework-agnostic library that provides state machines for building accessible, interactive components. When a component mounts, the hook invokes the appropriate state machine to add accessibility and interactive features.

Zag is not distributed as a single npm package, but rather as a set of individual packages for each component. The `salad.add` task will install the correct package for the component and also import it in an `index.js` file in user's project. This way, the hook could access to the correct packages for each component dynamically. The `salad.init` task is also modified to do the neccesary setup in order to use the hook.

To make a component works with the hook:

- Add `phx-hook="ZagHook"` attribute and an `id` to the component's root element. For components that don't need a manual `id` we can use the `unique_id` helper to generate a random id.

- Add `data-component="component-name"` to the root element. This should match the Zag component you want to target. The name typically matches the name of the SaladUI component, but it can be different if needed.

- Add a `data-parts` attribute to the component's root element to indicate its structure. For example, in the `collapsible` component, the `trigger` and `content` are both parts of the component, so we set: `data-parts={Jason.encode!["trigger", "content"]}`. For components containing items with their own parts (like accordions), we don't need to include the item parts here.

- For components that contain other components, like `accordion_item`, we follow the same pattern. So, in the accordion item component: `data-parts={Jason.encode!(["trigger", "content"])}`. Additionally, these types of components require a `data-value` attribute. For instace, we could use something like: `data-value="accordion-item-1`.

- Add a `data-part` attribute to each part of the component. The value should be the name of the part. For example, in the collapsible component, we have: `data-parts={Jason.encode!(["trigger", "content"])}`, so we need to add `data-part="trigger"` and `data-part="content"` to the `collapsible_trigger` and `collapsible_content` components respectively. Is not necessary to add the `data-part="root"` attribute to the root component. For components that are items, like `accordion_item`, we need to add `data-part="item"` to identify it as a part with its own parts.

- (optional) Add a `data-options` attribute to the component's root element. This is a map with all options that Zag accepts for the component. The keys are the name of the options (in any case, the hook will convert them to camelCase) and the values are the posibles values for that option, as an array. If the option is a boolean, pass `:bool` instead. Each option also needs to have a corresponding `data-option` attribute with the value of the option. For example, we could set: `data-options={Jason.encode!(%{open: :bool, direction: ["ltr", "rtl"]})} data-open={@open} data-direction={@direction}`. All of this should match the Zag api for the component.

- (optional) Add a `data-listeners` attribute to the component's root element. This is a list of events that the component could emit from the client to the server. The hook will add the corresponding listeners to the component. This follows the Zag api for events where each event is called: `onEventChange`. As the naming is consistent, we only need to provide the event name in the `data-listeners` attribute, in lower case, and the hook will find the correct event. For example, in the `collapsible` component, we could set: `data-listeners={Jason.encode!(["open"])}` to listen to the `onOpenChange` event. It is probably better let the user set the value of `data-listeners`, as any event included in listeners will need to be handled in the live view or an exception will be raised. So, instead we should use: `data-listeners={Jason.encode!(@listeners)}`.

- (optionally) The hook will manage the interaction logic, so JS commands are not required in the component, but they remain functionals. We could keep them as public functions to allows users to programatically interact with the component.
