### PR TITLE
Fix dynamic_tag deprecations warning for LiveView 1.0rc7

### DIFF
--- a/lib/salad_ui/helpers.ex
+++ b/lib/salad_ui/helpers.ex
@@ -266,7 +266,7 @@ defmodule SaladUI.Helpers do
     assigns =
       assigns
       |> Map.delete(:tag)
-      |> assign(:name, name)
+      |> assign(:tag_name, name)
 
     dynamic_tag(assigns)
   end


### PR DESCRIPTION
**Will fix this warning:**

warning: Passing the tag name to `Phoenix.Component.dynamic_tag/1` using the `name` attribute is deprecated.

Instead of:

    <.dynamic_tag name="p" ...>

use `tag_name` instead:

    <.dynamic_tag tag_name="p" ...>

## Summary by Sourcery

Bug Fixes:
- Fix deprecation warning by replacing the 'name' attribute with 'tag_name' in dynamic_tag usage.