### PR TITLE
fix: tab doc typo, bad link and indentation

### DIFF
--- a/lib/salad_ui/tabs.ex
+++ b/lib/salad_ui/tabs.ex
@@ -1,29 +1,28 @@
 defmodule SaladUI.Tabs do
   @moduledoc """
-  Implement of card components from https://ui.shadcn.com/docs/components/card
-
+  Implementation of tabs components from https://ui.shadcn.com/docs/components/tabs
 
   ## Example:
 
       <.tabs default="account" id="settings" :let={builder} class="w-[400px]">
-      <.tabs_list class="grid w-full grid-cols-2">
-        <.tabs_trigger builder={builder} value="account">account</.tabs_trigger>
-        <.tabs_trigger builder={builder} value="password">password</.tabs_trigger>
-      </.tabs_list>
-      <.tabs_content value="account">
+        <.tabs_list class="grid w-full grid-cols-2">
+          <.tabs_trigger builder={builder} value="account">account</.tabs_trigger>
+          <.tabs_trigger builder={builder} value="password">password</.tabs_trigger>
+        </.tabs_list>
+        <.tabs_content value="account">
           <.card>
-          <.card_content class="p-6">
-            Account
-          </.card_content>
-        </.card>
-      </.tabs_content>
-      <.tabs_content value="password">
-        <.card>
-          <.card_content class="p-6">
-            Password
-          </.card_content>
-        </.card>
-      </.tabs_content>
+            <.card_content class="p-6">
+              Account
+            </.card_content>
+          </.card>
+        </.tabs_content>
+        <.tabs_content value="password">
+          <.card>
+            <.card_content class="p-6">
+              Password
+            </.card_content>
+          </.card>
+        </.tabs_content>
       </.tabs>
   """
   use SaladUI, :component


### PR DESCRIPTION
## Summary by Sourcery

Fix documentation issues in the SaladUI.Tabs module by correcting a link and improving code indentation.

Bug Fixes:
- Correct the documentation link for the tabs component in the SaladUI.Tabs module.
- Fix indentation issues in the example code within the SaladUI.Tabs module documentation.