### PR TITLE
fix docs and wording

### DIFF
--- a/README.md
+++ b/README.md
@@ -141,9 +141,11 @@ It's also important to note that you must format your code with `mix format` bef
 - ✅ Dropdown Menu
 - ✅ Form
 - ✅ Hover Card
+- ✅ Icon
 - ✅ Input
 - [ ] Input OTP
 - ✅ Label
+- ✅ Menu
 - ✅ Pagination
 - ✅ Popover
 - ✅ Progress
@@ -159,9 +161,9 @@ It's also important to note that you must format your code with `mix format` bef
 - ✅ Table
 - ✅ Tabs
 - ✅ Textarea
-- ✅ Tooltip
 - ✅ Toggle
 - ✅ Toggle Group
+- ✅ Tooltip
 
 ## 🌟 Contributors
 

--- a/lib/mix/tasks/salad.init.ex
+++ b/lib/mix/tasks/salad.init.ex
@@ -50,7 +50,7 @@ defmodule Mix.Tasks.Salad.Init do
          :ok <- maybe_write_component_module(component_path, app_name, opts),
          :ok <- install_node_dependencies(node_opts) do
       if opts[:as_lib] do
-        Mix.shell().info("Done. Now you can use any component by importSaladUI.<ComponentName> in your project.")
+        Mix.shell().info("Done. Now you can use any component by `import SaladUI.<ComponentName>` in your project.")
       else
         Mix.shell().info("Done. Now you can add components by running mix salad.add <component_name>")
       end


### PR DESCRIPTION
The output was:

```
Done. Now you can use any component by importSaladUI.<ComponentName> in your project.
```

Now:

```
Done. Now you can use any component by `import SaladUI.<ComponentName>` in your project.
```

And added some missing components to the readme.

## Summary by Sourcery

Update documentation to correct import statement format and include missing components in the README.

Documentation:
- Corrected the import statement format in the output message for better readability.
- Added missing components 'Icon' and 'Menu' to the README component list.