### PR TITLE
Dialog on_cancel

### DIFF
--- a/lib/salad_ui/dialog.ex
+++ b/lib/salad_ui/dialog.ex
@@ -51,6 +51,7 @@ defmodule SaladUI.Dialog do
       phx-remove={JS.exec("phx-hide-modal", to: "##{@id}")}
       phx-show-modal={show_modal(@id)}
       phx-hide-modal={hide_modal(@id)}
+      data-cancel={JS.exec(@on_cancel, "phx-remove")}
       class="relative z-50 hidden group/dialog"
     >
       <div
@@ -66,9 +67,9 @@ defmodule SaladUI.Dialog do
       >
         <.focus_wrap
           id={"#{@id}-wrap"}
-          phx-window-keydown={JS.exec("phx-hide-modal", to: "##{@id}")}
+          phx-window-keydown={JS.exec("data-cancel", to: "##{@id}")}
           phx-key="escape"
-          phx-click-away={JS.exec("phx-hide-modal", to: "##{@id}")}
+          phx-click-away={JS.exec("data-cancel", to: "##{@id}")}
           class="w-full sm:max-w-[425px]"
         >
           <div


### PR DESCRIPTION
Dialog with the same behavior that the modal core component of phoenix. In the case the user pass the on_cancel attribute it will execute the JS and then the phx-remove.
If the user don't pass we will keep the same behavior.

Before:

https://github.com/user-attachments/assets/0871ec07-68d1-4f56-ae26-ca0df50e1ffa

After:

https://github.com/user-attachments/assets/a386a572-d8e2-4e3f-8cef-9b65968e922b

## Summary by Sourcery

New Features:
- Introduce an 'on_cancel' attribute for the Dialog component to execute custom JavaScript before the default 'phx-remove' action.