### PR TITLE
Modify salad.init task to automatically add TwMerge.Cache

### DIFF
--- a/lib/mix/tasks/salad.init.ex
+++ b/lib/mix/tasks/salad.init.ex
@@ -36,12 +36,14 @@ defmodule Mix.Tasks.Salad.Init do
     env = Atom.to_string(Mix.env())
     app_name = Mix.Project.config()[:app] |> Atom.to_string() |> String.downcase()
     assets_path = build_assets_path(env)
+    application_file_path = Path.join(File.cwd!(), "lib/#{app_name}/application.ex")
 
     node_opts = if env == "test", do: [skip: true], else: []
 
     File.mkdir_p!(component_path)
 
     with :ok <- write_config(component_path),
+         :ok <- init_tw_merge_cache(application_file_path),
          :ok <- patch_css(color_scheme, assets_path),
          :ok <- patch_js(assets_path),
          :ok <- copy_tailwind_colors(assets_path),
@@ -114,6 +116,23 @@ defmodule Mix.Tasks.Salad.Init do
       :ok
     else
       {:error, "#{Path.basename(config_path)} not found"}
+    end
+  end
+
+  defp init_tw_merge_cache(application_file_path) do
+    cache_module = "TwMerge.Cache"
+    description = "Start TwMerge cache"
+
+    Mix.shell().info("Adding Tailwind merge cache to application supervisor")
+
+    if File.exists?(application_file_path) do
+      Patcher.patch_elixir_application(
+        application_file_path,
+        cache_module,
+        description
+      )
+    else
+      {:error, "application.ex not found"}
     end
   end
 

--- a/lib/salad_ui/patcher.ex
+++ b/lib/salad_ui/patcher.ex
@@ -8,6 +8,7 @@ defmodule SaladUI.Patcher do
 
   alias SaladUI.Patcher.ConfigPatcher
   alias SaladUI.Patcher.CSSPatcher
+  alias SaladUI.Patcher.ElixirPatcher
   alias SaladUI.Patcher.JSPatcher
   alias SaladUI.Patcher.TailwindPatcher
 
@@ -23,6 +24,19 @@ defmodule SaladUI.Patcher do
   """
   def patch_config(config_path, configs) do
     ConfigPatcher.patch(config_path, configs: configs)
+  end
+
+  @doc """
+  Patches the Elixir application supervisor to add a new child.
+
+  ## Parameters
+
+  - application_file_path: Path to the Elixir application file
+  - new_children: The new children to add to the supervisor
+  - description: A description for the new children
+  """
+  def patch_elixir_application(application_file_path, new_children, description \\ nil) do
+    ElixirPatcher.patch_application_supervisor(application_file_path, new_children, description)
   end
 
   @doc """

--- a/lib/salad_ui/patcher/elixir_patcher.ex
+++ b/lib/salad_ui/patcher/elixir_patcher.ex
@@ -1,0 +1,84 @@
+defmodule SaladUI.Patcher.ElixirPatcher do
+  @moduledoc false
+
+  def patch_application_supervisor(application_file_path, new_children, description \\ nil) do
+    new_content =
+      application_file_path
+      |> File.read!()
+      |> update_content(new_children, description)
+
+    case new_content do
+      {:ok, new_content} -> File.write!(application_file_path, new_content)
+      {:error, _} = error -> error
+    end
+  end
+
+  defp update_content(content, new_children, description) do
+    cond do
+      # If the new children already exists, do nothing
+      Regex.match?(~r/\[([^\]]*#{Regex.escape(new_children)}[^\]]*)\]/m, content) ->
+        {:ok, content}
+
+      # Try to find and modify an existing children variable
+      Regex.match?(~r/children\s*=\s*\[/m, content) ->
+        {:ok,
+         Regex.replace(
+           ~r/(children\s*=\s*\[)([^\]]*)/m,
+           content,
+           fn _, opening, existing_elements ->
+             if single_line_list?(existing_elements) do
+               "#{opening}#{new_children}, #{existing_elements}"
+             else
+               indentation =
+                 extract_indentation(existing_elements) || "  "
+
+               to_add = build_addition(new_children, description, indentation)
+               "#{opening}\n#{to_add},#{existing_elements}"
+             end
+           end
+         )}
+
+      # If no children list found, look for Supervisor.start_link call
+      Regex.match?(~r/Supervisor\.start_link\(\s*\[/m, content) ->
+        {:ok,
+         Regex.replace(
+           ~r/(Supervisor\.start_link\(\s*\[)([^\]]*)/m,
+           content,
+           fn _, opening, existing_elements ->
+             if single_line_list?(existing_elements) do
+               "#{opening}#{new_children}, #{existing_elements}"
+             else
+               indentation = extract_indentation(existing_elements) || "  "
+
+               to_add = build_addition(new_children, description, indentation)
+               "#{opening}\n#{to_add},#{existing_elements}"
+             end
+           end
+         )}
+
+      # Otherwise, return an error
+      true ->
+        {:error,
+         "Could not find a location to add the child to the supervisor. Please add TwMerge.Cache to your supervisor."}
+    end
+  end
+
+  defp single_line_list?(list_content) do
+    not String.contains?(list_content, "\n")
+  end
+
+  defp extract_indentation(list_content) do
+    list_content
+    |> String.split("\n")
+    |> Enum.find_value(fn line ->
+      if String.match?(line, ~r/^\s*\S/), do: ~r/^\s*/ |> Regex.run(line) |> List.first()
+    end)
+  end
+
+  defp build_addition(new_children, description, element_indentation) do
+    addition =
+      if description, do: "# #{description}\n#{new_children}", else: new_children
+
+    addition |> String.split("\n") |> Enum.map_join("\n", &"#{element_indentation}#{&1}")
+  end
+end

--- a/lib/salad_ui/patcher/elixir_patcher.ex
+++ b/lib/salad_ui/patcher/elixir_patcher.ex
@@ -26,14 +26,19 @@ defmodule SaladUI.Patcher.ElixirPatcher do
            ~r/(children\s*=\s*\[)([^\]]*)/m,
            content,
            fn _, opening, existing_elements ->
+             existing_elements =
+               if single_element_list?(existing_elements),
+                 do: "",
+                 else: ", #{existing_elements}"
+
              if single_line_list?(existing_elements) do
-               "#{opening}#{new_children}, #{existing_elements}"
+               "#{opening}#{new_children}#{existing_elements}"
              else
                indentation =
                  extract_indentation(existing_elements) || "  "
 
                to_add = build_addition(new_children, description, indentation)
-               "#{opening}\n#{to_add},#{existing_elements}"
+               "#{opening}\n#{to_add}#{existing_elements}"
              end
            end
          )}
@@ -45,13 +50,18 @@ defmodule SaladUI.Patcher.ElixirPatcher do
            ~r/(Supervisor\.start_link\(\s*\[)([^\]]*)/m,
            content,
            fn _, opening, existing_elements ->
+             existing_elements =
+               if single_element_list?(existing_elements),
+                 do: "",
+                 else: ", #{existing_elements}"
+
              if single_line_list?(existing_elements) do
-               "#{opening}#{new_children}, #{existing_elements}"
+               "#{opening}#{new_children}#{existing_elements}"
              else
                indentation = extract_indentation(existing_elements) || "  "
 
                to_add = build_addition(new_children, description, indentation)
-               "#{opening}\n#{to_add},#{existing_elements}"
+               "#{opening}\n#{to_add}#{existing_elements}"
              end
            end
          )}
@@ -65,6 +75,10 @@ defmodule SaladUI.Patcher.ElixirPatcher do
 
   defp single_line_list?(list_content) do
     not String.contains?(list_content, "\n")
+  end
+
+  defp single_element_list?(list_content) do
+    list_content == ""
   end
 
   defp extract_indentation(list_content) do

--- a/test/mix/salad.init_test.exs
+++ b/test/mix/salad.init_test.exs
@@ -5,6 +5,7 @@ defmodule Mix.Tasks.Salad.InitTest do
 
   @tmp_dir "test_init"
   @default_components_path Path.join(["lib/test_app_web/components"])
+  @application_file_path "lib/salad_ui/application.ex"
 
   setup do
     # The shell asks for a path to install components.
@@ -25,12 +26,14 @@ defmodule Mix.Tasks.Salad.InitTest do
       File.write!("mix.exs", "defmodule SaladUI.MixProject do use Mix.Project\nend")
 
       File.mkdir_p!("config")
+      File.mkdir_p!(Path.dirname(@application_file_path))
       File.mkdir_p!("assets/css")
       File.mkdir_p!("assets/js")
       File.mkdir_p!(@default_components_path)
 
       File.write!("config/config.exs", "import Config\n")
       File.write!("config/dev.exs", "import Config\n")
+      File.write!(@application_file_path, "children = []\n")
       File.write!("assets/css/app.css", "/* Original app.css content */\n")
       File.write!("assets/js/app.js", "// Original app.js content\n")
       File.write!("assets/tailwind.config.js", "module.exports = {\n  // Original tailwind config\n}\n")
@@ -51,6 +54,9 @@ defmodule Mix.Tasks.Salad.InitTest do
       dev_config_content = File.read!("config/dev.exs")
       assert dev_config_content =~ "config :salad_ui, components_path:"
       assert dev_config_content =~ "Path.join(File.cwd!(), \"#{@default_components_path}\")"
+
+      application_file_content = File.read!(@application_file_path)
+      assert application_file_content =~ "TwMerge.Cache"
 
       assert File.read!("assets/css/app.css") =~ "/* gray theme */"
       assert File.read!("assets/js/app.js") =~ "// server events"

--- a/test/salad_ui/patcher/elixir_patcher_test.exs
+++ b/test/salad_ui/patcher/elixir_patcher_test.exs
@@ -1,0 +1,95 @@
+defmodule SaladUI.Patcher.ElixirPatcherTest do
+  use ExUnit.Case, async: true
+
+  alias SaladUI.Patcher.ElixirPatcher
+
+  @temp_dir "tmp/test"
+  @application_file_path Path.join(@temp_dir, "lib/salad_ui/application.ex")
+
+  setup do
+    File.mkdir_p!(Path.dirname(@application_file_path))
+    File.touch!(@application_file_path)
+    on_exit(fn -> File.rm_rf!(Path.dirname(@application_file_path)) end)
+    %{file_path: @application_file_path}
+  end
+
+  describe "Test elixir patcher" do
+    test "patch_application_supervisor/3 adds new children to an existing children list", %{file_path: file_path} do
+      initial_content = """
+      defmodule MyApp.Application do
+        def start(_type, _args) do
+          children = [
+            MyApp.Worker
+          ]
+          Supervisor.start_link(children, strategy: :one_for_one)
+        end
+      end
+      """
+
+      File.write!(file_path, initial_content)
+
+      new_children = "MyApp.NewWorker"
+      ElixirPatcher.patch_application_supervisor(file_path, new_children)
+
+      result = File.read!(file_path)
+      assert result =~ "MyApp.NewWorker"
+    end
+
+    test "patch_application_supervisor/3 adds a new children in a Supervisor.start_link call", %{file_path: file_path} do
+      initial_content = """
+      defmodule MyApp.Application do
+        def start(_type, _args) do
+          Supervisor.start_link([], strategy: :one_for_one)
+        end
+      end
+      """
+
+      File.write!(file_path, initial_content)
+
+      new_children = "MyApp.NewWorker"
+      ElixirPatcher.patch_application_supervisor(file_path, new_children)
+
+      result = File.read!(file_path)
+      assert result =~ "Supervisor.start_link([MyApp.NewWorker], strategy: :one_for_one)"
+    end
+
+    test "patch_application_supervisor/3 does not duplicate existing children", %{file_path: file_path} do
+      initial_content = """
+      defmodule MyApp.Application do
+        def start(_type, _args) do
+          children = [
+            MyApp.Worker,
+            MyApp.NewWorker
+          ]
+          Supervisor.start_link(children, strategy: :one_for_one)
+        end
+      end
+      """
+
+      File.write!(file_path, initial_content)
+
+      new_children = "MyApp.NewWorker"
+      ElixirPatcher.patch_application_supervisor(file_path, new_children)
+
+      result = File.read!(file_path)
+      assert result =~ "MyApp.NewWorker"
+      assert String.contains?(result, "MyApp.NewWorker") == true
+    end
+
+    test "patch_application_supervisor/3 returns an error when no suitable location is found", %{file_path: file_path} do
+      initial_content = """
+      defmodule MyApp.Application do
+        def start(_type, _args) do
+        end
+      end
+      """
+
+      File.write!(file_path, initial_content)
+
+      new_children = "MyApp.NewWorker"
+
+      assert {:error, _} =
+               ElixirPatcher.patch_application_supervisor(file_path, new_children)
+    end
+  end
+end


### PR DESCRIPTION
The `salad.init` task now also patches the `application.ex` file to automatically include `TwMerge.Cache` as part of the setup process.

## Summary by Sourcery

Modify the salad.init task to automatically include TwMerge.Cache in the application supervisor setup. Add functionality to patch the Elixir application supervisor with new children, enhancing the initialization process.

New Features:
- Automatically add TwMerge.Cache to the application supervisor during the salad.init task.

Enhancements:
- Introduce a new function to patch the Elixir application supervisor with additional children.