### PR TITLE
Feature/tooltip accessibility

### DIFF
--- a/lib/salad_ui/radio_group.ex
+++ b/lib/salad_ui/radio_group.ex
@@ -30,7 +30,7 @@ defmodule SaladUI.RadioGroup do
   attr :field, Phoenix.HTML.FormField, doc: "a form field struct retrieved from the form, for example: @form[:email]"
   attr :class, :string, default: nil
   attr :disabled, :boolean, default: false
-    attr :on_value_change, :string, default: nil, doc: "`push_event` event to push to server when select value changed"
+  attr :on_value_change, :string, default: nil, doc: "`push_event` event to push to server when select value changed"
 
   slot :inner_block, required: true
 
@@ -91,7 +91,7 @@ defmodule SaladUI.RadioGroup do
         </span>
       </span>
       {render_slot(@inner_block)}
-            <input
+      <input
         data-part="item-hidden-input"
         type="radio"
         class="hidden"
@@ -99,7 +99,6 @@ defmodule SaladUI.RadioGroup do
         checked={@builder.value == @value}
         {@rest}
       />
-
     </label>
     """
   end

--- a/lib/salad_ui/tooltip.ex
+++ b/lib/salad_ui/tooltip.ex
@@ -22,6 +22,10 @@ defmodule SaladUI.Tooltip do
   def tooltip(assigns) do
     ~H"""
     <div
+      data-component="tooltip"
+      data-parts={Jason.encode!(["trigger", "content"])}
+            data-options={Jason.encode!(%{})}
+            phx-hook="ZagHook"
       class={
         classes([
           "relative group/tooltip inline-block",
@@ -60,6 +64,7 @@ defmodule SaladUI.Tooltip do
 
     ~H"""
     <div
+      data-part="positioner"
       data-side={@side}
       class={
         classes([
@@ -71,7 +76,9 @@ defmodule SaladUI.Tooltip do
       }
       {@rest}
     >
-      {render_slot(@inner_block)}
+      <div data-part="content">
+        {render_slot(@inner_block)}
+        </div>
     </div>
     """
   end

--- a/lib/salad_ui/tooltip.ex
+++ b/lib/salad_ui/tooltip.ex
@@ -16,6 +16,7 @@ defmodule SaladUI.Tooltip do
 
   """
   attr :class, :string, default: nil
+  attr :side, :string, default: "top", values: ~w(bottom left right top)
   attr :rest, :global
   slot :inner_block, required: true
 
@@ -23,15 +24,16 @@ defmodule SaladUI.Tooltip do
     ~H"""
     <div
       data-component="tooltip"
-      data-parts={Jason.encode!(["trigger", "content"])}
-            data-options={Jason.encode!(%{})}
-            phx-hook="ZagHook"
-      class={
-        classes([
-          "relative group/tooltip inline-block",
-          @class
-        ])
+      data-parts={Jason.encode!(["root", "trigger", "positioner", "content"])}
+      data-part="root"
+      data-options={
+        Jason.encode!(%{
+          id: unique_id(),
+          positioning: %{strategy: "fixed", placement: @side}
+        })
       }
+      phx-hook="ZagHook"
+      class={@class}
       {@rest}
     >
       {render_slot(@inner_block)}
@@ -42,11 +44,15 @@ defmodule SaladUI.Tooltip do
   @doc """
   Render only for compatible with shad ui
   """
+  attr :class, :string, default: nil
+  attr :rest, :global
   slot :inner_block, required: true
 
   def tooltip_trigger(assigns) do
     ~H"""
-    {render_slot(@inner_block)}
+    <div data-part="trigger" class={@class} {@rest}>
+      {render_slot(@inner_block)}
+    </div>
     """
   end
 
@@ -54,31 +60,25 @@ defmodule SaladUI.Tooltip do
   Render
   """
   attr :class, :string, default: nil
-  attr :side, :string, default: "top", values: ~w(bottom left right top)
   attr :rest, :global
   slot :inner_block, required: true
 
   def tooltip_content(assigns) do
-    assigns =
-      assign(assigns, :variant_class, side_variant(assigns.side))
-
     ~H"""
-    <div
-      data-part="positioner"
-      data-side={@side}
-      class={
-        classes([
-          "tooltip-content absolute whitespace-nowrap hidden group-hover/tooltip:block",
-          "z-50 w-auto overflow-hidden rounded-md border bg-popover px-3 py-1.5 text-sm text-popover-foreground shadow-md animate-in fade-in-0 zoom-in-95 data-[side=bottom]:slide-in-from-top-2 data-[side=left]:slide-in-from-right-2 data-[side=right]:slide-in-from-left-2 data-[side=top]:slide-in-from-bottom-2",
-          @variant_class,
-          @class
-        ])
-      }
-      {@rest}
-    >
-      <div data-part="content">
+    <div data-part="positioner">
+      <div
+        data-part="content"
+        hidden
+        class={
+          classes([
+            "z-50 overflow-hidden rounded-md border bg-popover px-3 py-1.5 text-sm text-popover-foreground shadow-md animate-in fade-in-0 zoom-in-95 data-[state=closed]:animate-out data-[state=closed]:fade-out-0 data-[state=closed]:zoom-out-95 data-[placement=bottom]:slide-in-from-top-2 data-[placement=left]:slide-in-from-right-2 data-[placement=right]:slide-in-from-left-2 data-[placement=top]:slide-in-from-bottom-2",
+            @class
+          ])
+        }
+        {@rest}
+      >
         {render_slot(@inner_block)}
-        </div>
+      </div>
     </div>
     """
   end


### PR DESCRIPTION
## Summary by Sourcery

Update select, radio group, and toggle group components to use ZagJS for enhanced accessibility and interactivity. Add new ZagHook and supporting files for integration. Install necessary ZagJS packages and update `assets/js/zag/index.js` to export the new components.

New Features:
- Implement accessibility and interactive features for select, radio group, and toggle group components using ZagJS.

Tests:
- Add integration tests for ZagJS components.