### PR TITLE
Improve parts handling

### DIFF
--- a/priv/static/assets/zag/component.js
+++ b/priv/static/assets/zag/component.js
@@ -90,15 +90,28 @@ export class Component {
   }
 
   renderPart(root, name, api, opts = {}) {
-    const isRoot = name === root.dataset.part;
-    const part = isRoot ? root : root.querySelector(`[data-part='${name}']`);
-
     const getterName = `get${camelize(name, true)}Props`;
-    // console.log(getterName, opts);
+    if (!api[getterName]) return;
 
-    if (part && api[getterName]) {
-      const cleanup = this.spreadProps(part, api[getterName](opts), isRoot);
-      this.cleanupFunctions.set(part, cleanup);
+    // wrapper around spreadProps
+    const spreadProps = (el, attrs, isRoot = false) => {
+      const cleanup = this.spreadProps(el, attrs, isRoot);
+      this.cleanupFunctions.set(el, cleanup);
+    };
+
+    const isRoot = name === "root";
+    if (isRoot) {
+      spreadProps(root, api[getterName](opts), isRoot);
+      return;
+    }
+
+    const elements = root.querySelectorAll(`[data-part='${name}']`);
+
+    for (const el of elements) {
+      let elOpts = { ...opts };
+      if (el.dataset.options) elOpts = JSON.parse(el.dataset.options);
+
+      spreadProps(el, api[getterName](elOpts));
     }
   }
 


### PR DESCRIPTION
Some components may have multiple element for the same part. For example, the `tabs` component has multiple `trigger` and multiple `content`. For that reason we need to call `spreadProps` for each element that has a `data-part` attribute.

Each `part` could also recieve its own options. This is required for components like `tabs` beacause each `trigger` and each `content` needs to carry a value to identify them properly.

## Summary by Sourcery

Update the `renderPart` method to handle multiple elements with the same part name and support per-element options.

New Features:
- Support multiple elements with the same part name within a component.
- Allow per-element options for individual parts.