### PR TITLE
Remove node dependencies

### DIFF
--- a/.envrc
+++ b/.envrc
@@ -1,0 +1,1 @@
+use flake

--- a/.gitignore
+++ b/.gitignore
@@ -32,3 +32,4 @@ node_modules/
 /.vscode/
 /.ctags.d/
 .tags
+/.direnv/

--- a/flake.lock
+++ b/flake.lock
@@ -1,0 +1,61 @@
+{
+  "nodes": {
+    "flake-utils": {
+      "inputs": {
+        "systems": "systems"
+      },
+      "locked": {
+        "lastModified": 1731533236,
+        "narHash": "sha256-l0KFg5HjrsfsO/JpG+r7fRrqm12kzFHyUHqHCVpMMbI=",
+        "owner": "numtide",
+        "repo": "flake-utils",
+        "rev": "11707dc2f618dd54ca8739b309ec4fc024de578b",
+        "type": "github"
+      },
+      "original": {
+        "owner": "numtide",
+        "repo": "flake-utils",
+        "type": "github"
+      }
+    },
+    "nixpkgs": {
+      "locked": {
+        "lastModified": 1737062831,
+        "narHash": "sha256-Tbk1MZbtV2s5aG+iM99U8FqwxU/YNArMcWAv6clcsBc=",
+        "owner": "nixos",
+        "repo": "nixpkgs",
+        "rev": "5df43628fdf08d642be8ba5b3625a6c70731c19c",
+        "type": "github"
+      },
+      "original": {
+        "owner": "nixos",
+        "ref": "nixos-unstable",
+        "repo": "nixpkgs",
+        "type": "github"
+      }
+    },
+    "root": {
+      "inputs": {
+        "flake-utils": "flake-utils",
+        "nixpkgs": "nixpkgs"
+      }
+    },
+    "systems": {
+      "locked": {
+        "lastModified": 1681028828,
+        "narHash": "sha256-Vy1rq5AaRuLzOxct8nz4T6wlgyUR7zLU309k9mBC768=",
+        "owner": "nix-systems",
+        "repo": "default",
+        "rev": "da67096a3b9bf56a91d16901293e51ba5b49a27e",
+        "type": "github"
+      },
+      "original": {
+        "owner": "nix-systems",
+        "repo": "default",
+        "type": "github"
+      }
+    }
+  },
+  "root": "root",
+  "version": 7
+}

--- a/flake.nix
+++ b/flake.nix
@@ -22,17 +22,10 @@
           buildInputs = with pkgs; [
             beam27Packages.elixir_1_17
             beam27Packages.erlang
-            nodejs_20
 
             # LSPs
             # lexical
             erlang-ls
-
-            # Tools
-            # yamllint
-            # yaml-language-server
-            # shfmt
-            # shellcheck
           ];
         };
       });

--- a/flake.nix
+++ b/flake.nix
@@ -1,0 +1,39 @@
+{
+  description = "Phoenix Liveview component library inspired by shadcn UI";
+
+  inputs = {
+    nixpkgs.url = "github:nixos/nixpkgs?ref=nixos-unstable";
+    flake-utils.url = "github:numtide/flake-utils";
+  };
+
+  outputs = { self, nixpkgs, flake-utils, ... }:
+    flake-utils.lib.eachDefaultSystem (system:
+      let
+        pkgs = import nixpkgs { inherit system; };
+
+        # NOTE:
+        # override since `elixir` is defaulting to 1.18 atm, and lexical doesn't support that version yet
+        lexical =
+          pkgs.lexical.override { elixir = pkgs.beam27Packages.elixir_1_17; };
+      in {
+        devShells.default = pkgs.mkShell {
+          packages = [ lexical ];
+
+          buildInputs = with pkgs; [
+            beam27Packages.elixir_1_17
+            beam27Packages.erlang
+            nodejs_20
+
+            # LSPs
+            # lexical
+            erlang-ls
+
+            # Tools
+            # yamllint
+            # yaml-language-server
+            # shfmt
+            # shellcheck
+          ];
+        };
+      });
+}

--- a/lib/salad_ui/patcher/tailwind_patcher.ex
+++ b/lib/salad_ui/patcher/tailwind_patcher.ex
@@ -5,7 +5,7 @@ defmodule SaladUI.Patcher.TailwindPatcher do
   # so the user does not to manually format his `tailwind.config.js`
   # file after patching it.
 
-  @plugins ["@tailwindcss/typography", "tailwindcss-animate"]
+  @plugins ["@tailwindcss/typography", "./vendor/tailwindcss-animate"]
   @tailwind_colors "./tailwind.colors.json"
 
   def patch(tailwind_config_path, opts \\ []) do

--- a/test/mix/salad.init_test.exs
+++ b/test/mix/salad.init_test.exs
@@ -29,6 +29,7 @@ defmodule Mix.Tasks.Salad.InitTest do
       File.mkdir_p!(Path.dirname(@application_file_path))
       File.mkdir_p!("assets/css")
       File.mkdir_p!("assets/js")
+      File.mkdir_p!("assets/vendor")
       File.mkdir_p!(@default_components_path)
 
       File.write!("config/config.exs", "import Config\n")

--- a/test/salad_ui/patcher/tailwind_patcher_test.exs
+++ b/test/salad_ui/patcher/tailwind_patcher_test.exs
@@ -21,7 +21,7 @@ defmodule SaladUI.Patcher.TailwindPatcherTest do
       patched_content = File.read!(@tailwind_config)
       assert patched_content =~ "plugins: ["
       assert patched_content =~ "require(\"@tailwindcss/typography\")"
-      assert patched_content =~ "require(\"tailwindcss-animate\")"
+      assert patched_content =~ "require(\"./vendor/tailwindcss-animate\")"
     end
 
     test "patch/1 doesn't duplicate existing plugins" do
@@ -29,7 +29,7 @@ defmodule SaladUI.Patcher.TailwindPatcherTest do
       module.exports = {
         plugins: [
           require("@tailwindcss/typography"),
-          require("tailwindcss-animate")
+          require("./vendor/tailwindcss-animate")
         ]
       }
       """
@@ -41,11 +41,11 @@ defmodule SaladUI.Patcher.TailwindPatcherTest do
       patched_content = File.read!(@tailwind_config)
 
       assert patched_content =~ "require(\"@tailwindcss/typography\")"
-      assert patched_content =~ "require(\"tailwindcss-animate\")"
+      assert patched_content =~ "require(\"./vendor/tailwindcss-animate\")"
 
       # Count occurrences of each plugin
       typography_count = patched_content |> String.split("@tailwindcss/typography") |> length() |> Kernel.-(1)
-      animate_count = patched_content |> String.split("tailwindcss-animate") |> length() |> Kernel.-(1)
+      animate_count = patched_content |> String.split("./vendor/tailwindcss-animate") |> length() |> Kernel.-(1)
 
       assert typography_count == 1
       assert animate_count == 1


### PR DESCRIPTION
resolves #112

## Summary

This change removes the need to depend on node entirely by replacing `tailwindcss-animate` and download the source code directly from GitHub, and put the source into `assets/vendor`.

`Init` will also update the references to `tailwindcss-animate` and tests are updated as well.

Related change: https://github.com/bluzky/salad_storybook/pull/24

## Note

The Nix flake stuff is just something I need to setup for local development since I don't have Elixir downloaded outside projects.
It also helps with people who uses Nix to get all the dev deps they need easily.

## Summary by Sourcery

Remove the Node.js dependency by downloading the `tailwindcss-animate` source code directly and placing it in the `assets/vendor` directory.

Build:
- Download `tailwindcss-animate.js` on initialization instead of relying on `npm install`.

Tests:
- Update tests to reflect the new location of `tailwindcss-animate`.