### PR TITLE
Support bind zag api values to elements

### DIFF
--- a/priv/static/assets/zag/component.js
+++ b/priv/static/assets/zag/component.js
@@ -112,6 +112,15 @@ export class Component {
       if (el.dataset.options) elOpts = JSON.parse(el.dataset.options);
 
       spreadProps(el, api[getterName](elOpts));
+      if (!el.hasAttribute("data-api-bind")) continue;
+
+      // if the element has a data-api-bind attribute,
+      // bind its text content to the value provided by the api
+      const apiBind = el.dataset.apiBind;
+      if (!apiBind || !this.api[apiBind]) continue;
+
+      const apiValue = this.api[apiBind];
+      el.textContent = Array.isArray(apiValue) ? apiValue[0] : apiValue;
     }
   }
 


### PR DESCRIPTION
Some components needs to display a dynamic value provided by the api exposed by Zag. For instance, the `slider` component can display a number indicating the slider's current value. Since this value isn't directly accessible in LiveView, we need to include it in the hook. The api property containing the value is specified using the `data-api-bind` attribute in the element.

## Summary by Sourcery

New Features:
- Allow binding Zag API values to elements using the `data-api-bind` attribute.