### PR TITLE
Add button type to toggle and toggle group button

### DIFF
--- a/lib/salad_ui/toggle.ex
+++ b/lib/salad_ui/toggle.ex
@@ -36,6 +36,7 @@ defmodule SaladUI.Toggle do
     <button
       onclick="this.querySelector('.toggle-input').click()"
       disabled={@disabled}
+      type="button"
       class={
         classes([
           "inline-flex items-center justify-center rounded-md text-sm font-medium ring-offset-background transition-colors hover:bg-muted hover:text-muted-foreground focus-visible:outline-none focus-visible:ring-2 focus-visible:ring-ring focus-visible:ring-offset-2 disabled:pointer-events-none disabled:opacity-50 has-[:checked]:bg-accent has-[:checked]:text-accent-foreground",

--- a/lib/salad_ui/toggle_group.ex
+++ b/lib/salad_ui/toggle_group.ex
@@ -82,6 +82,7 @@ defmodule SaladUI.ToggleGroup do
     ~H"""
     <button
       onclick="this.querySelector('.toggle-input').click()"
+      type="button"
       disabled={@disabled || @builder.disabled}
       class={
         classes([
@@ -114,6 +115,7 @@ defmodule SaladUI.ToggleGroup do
     ~H"""
     <button
       onclick="this.querySelector('.toggle-input').click()"
+      type="button"
       disabled={@disabled || @builder.disabled}
       class={
         classes([


### PR DESCRIPTION
## Summary by Sourcery

Add `type="button"` to toggle and toggle group buttons to prevent accidental form submissions.