### PR TITLE
Fix phoenix doesn't trigger form change event

### DIFF
--- a/lib/salad_ui/switch.ex
+++ b/lib/salad_ui/switch.ex
@@ -50,6 +50,6 @@ defmodule SaladUI.Switch do
   defp toggle(id) do
     %JS{}
     |> JS.toggle_attribute({"data-state", "checked", "unchecked"})
-    |> JS.toggle_attribute({"checked", true}, to: "##{id} input[type=checkbox]")
+    |> JS.dispatch("click", to: "##{id} input[type=checkbox]", bubbles: false)
   end
 end


### PR DESCRIPTION
## Summary by Sourcery

Bug Fixes:
- Fix the issue where the Phoenix framework does not trigger a form change event when toggling a switch.