### PR TITLE
fix wrong attr type

### DIFF
--- a/lib/salad_ui/chart.ex
+++ b/lib/salad_ui/chart.ex
@@ -78,7 +78,7 @@ defmodule SaladUI.Chart do
   attr :id, :string, required: true
   attr :name, :string, default: "", doc: "name of the chart for screen readers"
   attr :chart_config, :map, required: true
-  attr :chart_data, :map, required: true
+  attr :chart_data, :list, required: true
 
   def chart(assigns) do
     ~H"""

--- a/mix.exs
+++ b/mix.exs
@@ -4,7 +4,7 @@ defmodule SaladUI.MixProject do
   def project do
     [
       app: :salad_ui,
-      version: "0.14.7",
+      version: "0.14.8",
       elixir: "~> 1.14",
       elixirc_paths: elixirc_paths(Mix.env()),
       start_permanent: Mix.env() == :prod,


### PR DESCRIPTION
## Summary by Sourcery

Correct the `chart_data` attribute type and bump the version

Bug Fixes:
- Fix the `chart_data` attribute type from `map` to `list` in `SaladUI.Chart` component

Chores:
- Bump version to 0.14.8