### PR TITLE
Allow form attribute on textarea

### DIFF
--- a/lib/salad_ui/textarea.ex
+++ b/lib/salad_ui/textarea.ex
@@ -17,7 +17,7 @@ defmodule SaladUI.Textarea do
   attr :name, :string, default: nil
   attr :value, :string
   attr :class, :any, default: nil
-  attr :rest, :global
+  attr :rest, :global, include: ~w(form)
 
   def textarea(assigns) do
     ~H"""


### PR DESCRIPTION
## Summary by Sourcery

Enhancements:
- The `form` attribute is now supported on the `textarea` component, allowing it to be associated with a form outside of the component's parent form.