### PR TITLE
Allow disabled attribute on textarea

### DIFF
--- a/lib/salad_ui/textarea.ex
+++ b/lib/salad_ui/textarea.ex
@@ -17,7 +17,7 @@ defmodule SaladUI.Textarea do
   attr :name, :string, default: nil
   attr :value, :string
   attr :class, :any, default: nil
-  attr :rest, :global
+  attr :rest, :global, include: ~w(disabled)
 
   def textarea(assigns) do
     ~H"""


### PR DESCRIPTION
Enhancements:

The `disabled` attribute is now supported on the textarea component, allowing it to appear disabled

## Summary by Sourcery

Enhancements:
- Allow the `disabled` attribute on the textarea component.