### PR TITLE
Allow form and disabled attributes to a text area

### DIFF
--- a/lib/salad_ui/textarea.ex
+++ b/lib/salad_ui/textarea.ex
@@ -17,7 +17,7 @@ defmodule SaladUI.Textarea do
   attr :name, :string, default: nil
   attr :value, :string
   attr :class, :any, default: nil
-  attr :rest, :global
+  attr :rest, :global, include: ~w(disabled form)
 
   def textarea(assigns) do
     ~H"""


### PR DESCRIPTION
After merging these attributes in v1 (#165 and #153 ), I'd like to add them to v0 as currently is the one [published in Hex](https://hex.pm/packages/salad_ui) and the one we're currently using 😅

## Summary by Sourcery

Allow the `disabled` and `form` attributes to be passed to the textarea component.