### PR TITLE
Add field.id as for option to label when field is present

### DIFF
--- a/lib/salad_ui/form.ex
+++ b/lib/salad_ui/form.ex
@@ -110,6 +110,7 @@ defmodule SaladUI.Form do
   def form_label(assigns) do
     ~H"""
     <SaladUI.Label.label
+      for={field && field.id}
       class={
         classes([
           @error && "text-destructive",

--- a/lib/salad_ui/form.ex
+++ b/lib/salad_ui/form.ex
@@ -94,6 +94,7 @@ defmodule SaladUI.Form do
 
     ~H"""
     <SaladUI.Label.label
+      for={@field.id}
       class={
         classes([
           @error && "text-destructive",
@@ -110,7 +111,6 @@ defmodule SaladUI.Form do
   def form_label(assigns) do
     ~H"""
     <SaladUI.Label.label
-      for={field && field.id}
       class={
         classes([
           @error && "text-destructive",


### PR DESCRIPTION
## Summary by Sourcery

Make the label's `for` attribute equal to the field's ID when a field is present.