### PR TITLE
Fix: Stories crash and show a blank page

### DIFF
--- a/storybook/lib/salad_storybook_web/live/demo/sidebar_six.ex
+++ b/storybook/lib/salad_storybook_web/live/demo/sidebar_six.ex
@@ -9,7 +9,7 @@ defmodule SaladStorybookWeb.Demo.SidebarSix do
     user: %{
       name: "shadcn",
       email: "m@example.com",
-      avatar: "/avatars/shadcn.jpg"
+      avatar: "https://github.com/shadcn.png"
     },
     teams: [
       %{
@@ -398,7 +398,7 @@ defmodule SaladStorybookWeb.Demo.SidebarSix do
             <.dropdown_menu_label class="p-0 font-normal">
               <div class="flex items-center gap-2 px-1 py-1.5 text-left text-sm">
                 <.avatar class="h-8 w-8 rounded-lg">
-                  <.avatar_image src="{user.avatar}" alt="{user.name}"></.avatar_image>
+                  <.avatar_image src={@user.avatar} alt={@user.name} />
                   <.avatar_fallback class="rounded-lg">
                     CN
                   </.avatar_fallback>

--- a/storybook/storybook/examples/form_demo.story.exs
+++ b/storybook/storybook/examples/form_demo.story.exs
@@ -131,23 +131,18 @@ defmodule Storybook.Examples.FormDemo do
 
               <.form_item>
                 <.label>Color</.label>
-                <.select
-                  :let={select}
-                  field={f[:color]}
-                  id="color-select"
-                  name="color"
-                  placeholder="Select a color"
-                >
-                  <.select_trigger builder={select} class="w-[180px]" />
-                  <.select_content class="w-full" builder={select}>
+                <.select field={f[:color]} id="color-select" name="color">
+                  <.select_trigger class="w-[180px]">
+                    <.select_value placeholder="Select a color" />
+                  </.select_trigger>
+                  <.select_content>
                     <.select_group>
-                      <.select_item builder={select} value="red" label="Red"></.select_item>
-                      <.select_item builder={select} value="green" label="Blue"></.select_item>
-                      <.select_item builder={select} value="pink"></.select_item>
+                      <.select_item value="red">Red</.select_item>
+                      <.select_item value="blue">Blue</.select_item>
+                      <.select_item value="pink">Pink</.select_item>
                       <.select_separator />
-                      <.select_item builder={select} disabled value="yellow" label="YELLOW">
-                      </.select_item>
-                      <.select_item builder={select} value="purple"></.select_item>
+                      <.select_item disabled value="yellow">Yellow</.select_item>
+                      <.select_item value="purple">Purple</.select_item>
                     </.select_group>
                   </.select_content>
                 </.select>

--- a/storybook/storybook/examples/server_event.story.exs
+++ b/storybook/storybook/examples/server_event.story.exs
@@ -21,7 +21,7 @@ defmodule Storybook.Examples.ServerEvent do
   @impl true
   def render(assigns) do
     ~H"""
-    <.sheet>
+    <.sheet id="my-sheet">
       <.sheet_trigger target="my-sheet">
         <.button variant="outline">Open</.button>
       </.sheet_trigger>

--- a/storybook/storybook/salad_ui_component/breadcrumb.story.exs
+++ b/storybook/storybook/salad_ui_component/breadcrumb.story.exs
@@ -35,7 +35,7 @@ defmodule Storybook.SaladUIComponents.Breadcrumb do
             </.breadcrumb_item>
             <.breadcrumb_separator />
             <.breadcrumb_item>
-              <.dropdown_menu>
+              <.dropdown_menu id="breadcrumb-dropdown">
                 <.dropdown_menu_trigger class="flex items-center gap-1">
                   <.breadcrumb_ellipsis class="h-4 w-4" />
                   <span class="sr-only">toggle menu</span>

--- a/storybook/storybook/salad_ui_component/sheet.story.exs
+++ b/storybook/storybook/salad_ui_component/sheet.story.exs
@@ -1,4 +1,3 @@
-==> salad_ui
 defmodule Storybook.SaladUIComponents.Sheet do
   @moduledoc false
   use PhoenixStorybook.Story, :component


### PR DESCRIPTION
This PR fixes an issue where certain stories would crash during rendering and display a blank page.

## Summary by Sourcery

Align Storybook examples with updated UI component APIs to fix rendering crashes and ensure proper trigger-target relationships.

Bug Fixes:
- Update FormDemo story’s select markup to use new select_trigger/select_value API and proper child structure.
- Add id attributes to sheet and dropdown_menu components in server_event and breadcrumb stories for correct trigger linkage.
- Correct avatar image URL in SidebarSix story to avoid invalid path.

Enhancements:
- Remove obsolete annotation header from sheet story file.