### PR TITLE
Fix switch component resetting to unchecked on LiveView updates

### DIFF
--- a/lib/salad_ui/switch.ex
+++ b/lib/salad_ui/switch.ex
@@ -22,7 +22,7 @@ defmodule SaladUI.Switch do
   attr :id, :string, default: nil
   attr :name, :string, default: nil
   attr :class, :string, default: nil
-  attr :checked, :boolean, default: false
+  attr :checked, :boolean
   attr :disabled, :boolean, default: false
   attr :"on-checked-changed", :any, default: nil, doc: "Handler for value change event"
 
@@ -33,7 +33,7 @@ defmodule SaladUI.Switch do
     assigns = prepare_assign(assigns)
 
     # Normalize value for boolean
-    assigns = assign(assigns, :checked, normalize_boolean(assigns.checked))
+    assigns = assign_new(assigns, :checked, fn -> normalize_boolean(assigns.value) end)
 
     # Collect event mappings
     event_map =


### PR DESCRIPTION
Previously, the `<.switch />` component would reset its checked state to false whenever the LiveView updated.
This fix ensures the checked attribute remains in sync with the component state across updates, enabling the switch to function as a fully controlled input.

## Summary by Sourcery

Fix the switch component so its checked state no longer resets to unchecked on LiveView updates by removing the default and using assign_new to keep the checked attribute in sync with the component’s value.

Bug Fixes:
- Ensure the switch’s checked state persists across LiveView updates instead of always resetting to false

Enhancements:
- Remove the default false for the checked attribute and derive it from the component’s value with assign_new