### PR TITLE
Fix: Handle select with multiple and missing name attribute

### DIFF
--- a/assets/salad_ui/components/select.js
+++ b/assets/salad_ui/components/select.js
@@ -436,13 +436,10 @@ class SelectComponent extends Component {
 
     // Create new hidden inputs
     if (this.multiple) {
-      // Multiple select - create multiple inputs with array notation
-      const inputName = name ? `${name}[]` : "";
-
       values.forEach((value) => {
         const input = document.createElement("input");
         input.type = "hidden";
-        input.name = inputName;
+        input.name = name;
         input.value = value;
         this.el.appendChild(input);
       });


### PR DESCRIPTION
Previously, using a `<.select>` component with the multiple attribute but without providing a name would cause an update failure:

```javascript
select.js:375 Uncaught TypeError: Cannot read properties of null (reading 'instance') ...
```
This happened because the component generated an invalid input name (e.g., name[][]), leading to inconsistent form data and breaking internal updates.

Example:

```elixir
<.select multiple form={f[:name]} />
```

With this fix:
- If the user explicitly provides a name, they are responsible for ensuring it is valid.
- Otherwise, `SaladUI.Helpers.prepare_assign/1` automatically assigns a valid default name.

## Summary by Sourcery

Fix handling of multiple select components when no name attribute is provided by removing invalid array notation and relying on valid default names

Bug Fixes:
- Prevent TypeError by no longer generating empty or double-bracketed names for multiple hidden inputs

Enhancements:
- Use the provided name directly for hidden inputs in multiple selects instead of appending array notation