### PR TITLE
fix: remove stray `}` in Pagination and Breadcrumb HEEx templates (`phoenix_live_view >= 1.2` compat)

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,3 +1,8 @@
+# 0.14.10
+
+**Bug fixes**
+- Fix stray `}` in HEEx templates of `Pagination` and `Breadcrumb` components that caused `Phoenix.LiveView.TagEngine.Tokenizer.ParseError` with `phoenix_live_view >= 1.2.0`
+
 # 0.14.0
 
 **Changes**

--- a/lib/salad_ui/breadcrumb.ex
+++ b/lib/salad_ui/breadcrumb.ex
@@ -39,7 +39,6 @@ defmodule SaladUI.Breadcrumb do
         ])
       }
       {@rest}
-      }
     >
       {render_slot(@inner_block)}
     </nav>
@@ -63,7 +62,6 @@ defmodule SaladUI.Breadcrumb do
         ])
       }
       {@rest}
-      }
     >
       {render_slot(@inner_block)}
     </ol>

--- a/lib/salad_ui/pagination.ex
+++ b/lib/salad_ui/pagination.ex
@@ -47,7 +47,6 @@ defmodule SaladUI.Pagination do
         ])
       }
       {@rest}
-      }
     >
       {render_slot(@inner_block)}
     </nav>
@@ -71,7 +70,6 @@ defmodule SaladUI.Pagination do
         ])
       }
       {@rest}
-      }
     >
       {render_slot(@inner_block)}
     </ul>

--- a/lib/salad_ui/textarea.ex
+++ b/lib/salad_ui/textarea.ex
@@ -17,7 +17,7 @@ defmodule SaladUI.Textarea do
   attr :name, :string, default: nil
   attr :value, :string
   attr :class, :any, default: nil
-  attr :rest, :global
+  attr :rest, :global, include: ~w(disabled form)
 
   def textarea(assigns) do
     ~H"""

--- a/lib/salad_ui/textarea.ex
+++ b/lib/salad_ui/textarea.ex
@@ -17,7 +17,7 @@ defmodule SaladUI.Textarea do
   attr :name, :string, default: nil
   attr :value, :string
   attr :class, :any, default: nil
-  attr :rest, :global, include: ~w(disabled form)
+  attr :rest, :global, include: ~w(disabled form placeholder rows cols maxlength minlength readonly required autocomplete autofocus)
 
   def textarea(assigns) do
     ~H"""

--- a/mix.exs
+++ b/mix.exs
@@ -4,7 +4,7 @@ defmodule SaladUI.MixProject do
   def project do
     [
       app: :salad_ui,
-      version: "0.14.8",
+      version: "0.14.9",
       elixir: "~> 1.14",
       elixirc_paths: elixirc_paths(Mix.env()),
       start_permanent: Mix.env() == :prod,

--- a/mix.exs
+++ b/mix.exs
@@ -4,7 +4,7 @@ defmodule SaladUI.MixProject do
   def project do
     [
       app: :salad_ui,
-      version: "0.14.9",
+      version: "0.14.10",
       elixir: "~> 1.14",
       elixirc_paths: elixirc_paths(Mix.env()),
       start_permanent: Mix.env() == :prod,


### PR DESCRIPTION
## Problem

`phoenix_live_view 1.2.0` introduced a stricter HEEx tokenizer that raises a `ParseError` when it encounters a bare `}` in tag attribute position:

`** (Phoenix.LiveView.TagEngine.Tokenizer.ParseError) expected attribute, but found end of interpolation: }`

Both `pagination.ex` and `breadcrumb.ex` had a stray `}` after `{@rest}` in the opening tags of two components each (4 occurrences total):

```heex
  <nav
    class={ ... }
    {@rest}
    }         ← stray }, causes ParseError on phoenix_live_view >= 1.2.0
  >
```

This caused `salad_ui 0.14.9` to fail to compile entirely when used alongside `phoenix_live_view >= 1.2.0`.

## Fix

Remove the 4 stray `}` characters:

- `lib/salad_ui/pagination.ex` — `pagination/1 and pagination_content/1`
- `lib/salad_ui/breadcrumb.ex` — `breadcrumb/1 and breadcrumb_list/1`

## Testing

Verify compilation succeeds with `phoenix_live_view >= 1.2.0`:
```
mix deps.compile salad_ui --force
```

## Summary by Sourcery

Fix HEEx compatibility issues and adjust textarea attributes for better HTML integration.

Bug Fixes:
- Remove stray `}` characters from Pagination and Breadcrumb HEEx templates to prevent Phoenix LiveView tokenizer parse errors with phoenix_live_view >= 1.2.0.

Enhancements:
- Restrict forwarded global attributes on the Textarea component to include only relevant HTML attributes such as `disabled` and `form`.

Build:
- Bump package version to 0.14.10.

Documentation:
- Document the HEEx template bug fix in the changelog.